### PR TITLE
Fix docs build by exporting version

### DIFF
--- a/codex/ledgers/ledger-versionalias-2506051710.json
+++ b/codex/ledgers/ledger-versionalias-2506051710.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506051710",
+  "agents": ["🧠 Mia", "🌸 Miette", "⚡ Jerry"],
+  "narrative": "Added __version__ attribute in package __init__ so docs can import version correctly. This ensures Sphinx build succeeds by reflecting package version from pyproject.",
+  "routing": {
+    "files": ["jgtpy/__init__.py"],
+    "branch": "codex/feature"
+  },
+  "verbatim_user_input": "(jgtpy) jgi@hu:/src/jgtpy$ make docs... ImportError: cannot import name '__version__' from 'jgtpy'",
+  "scene": "Before: docs build failed due to missing __version__. After: docs generate successfully, enabling improved packaging visibility."
+}

--- a/jgtpy/__init__.py
+++ b/jgtpy/__init__.py
@@ -37,6 +37,7 @@ with warnings.catch_warnings():
 
 
 version='0.5.110'
+__version__ = version
 
 
 # from JGTCDS import (


### PR DESCRIPTION
## Summary
- expose `__version__` in `jgtpy/__init__.py`
- record ledger entry for version alias fix

## Testing
- `make docs`
- `make test` *(fails: coverage not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cee9f5388329b31a8ee0a2381585