### PR TITLE
Fix cdscli to persist CDS and zone updates

### DIFF
--- a/codex/ledgers/ledger-feature-2506051931.json
+++ b/codex/ledgers/ledger-feature-2506051931.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506051931",
+  "agents": ["🧠 Mia", "🌸 Miette", "⚡ Jerry"],
+  "narrative": "Refactored cdscli to call JGTCDSSvc for creation and persist output. The CLI now writes CDS files, updates zone data and optionally displays ADS charts, aligning new service based workflow.",
+  "routing": {
+    "files": ["jgtpy/cdscli.py"],
+    "branch": "codex/feature"
+  },
+  "verbatim_user_input": "cdscli -i SPX500 -t D1 -mfi -ta -ba -new",
+  "scene": "Before: cdscli only returned data without saving or zone management. After: generated CDS files and zones support replacing jgtcli."
+}

--- a/jgtpy/cdscli.py
+++ b/jgtpy/cdscli.py
@@ -87,16 +87,25 @@ def main():
 
         for instrument in instruments:
             for timeframe in timeframes:
-                #rq=JGTCDSRequest.JGTCDSRequest.from_args(args)
-                
-                rq=JGTCDSRequest.JGTCDSRequest.from_args(args)
-                rq.instrument=instrument
-                rq.timeframe=timeframe
-                
-                cdf=svc.create(rq)
-                lcdf=len(cdf)
+                # Build request for this instrument/timeframe
+                rq = JGTCDSRequest.JGTCDSRequest.from_args(args)
+                rq.instrument = instrument
+                rq.timeframe = timeframe
+
+                # Generate CDS dataframe using service layer
+                cdf = svc.create(rq)
+
+                # Persist CDS to storage
+                cds.writeCDS(instrument, timeframe, rq.use_full, cdf)
+
+                # Update zone information
+                svc.zone_update_from_cdf(instrument, timeframe, cdf, quiet=args.quiet)
+
+                if verbose_level > 0:
+                    print(f"CDS len: {len(cdf)}")
+
                 if show_ads:
-                    ads_wrap(instrument,timeframe,cc)
+                    ads_wrap(instrument, timeframe, cc)
                 #svc.get(instrument,timeframe,args.full,args.fresh,args.quotescount,args.quiet)
                 # createCDS_for_main(
                 #     args.instrument,


### PR DESCRIPTION
## Summary
- write CDS files and update zones when running `cdscli`
- log CDS length and optionally plot ADS charts
- document changes in ledger

## Testing
- `make test` *(fails: coverage command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef6627008329b25bf180c28a49ae