### PR TITLE
Relocate LLMS.txt to project root

### DIFF
--- a/LLMS.txt
+++ b/LLMS.txt
@@ -1,0 +1,10 @@
+# LLMS.txt for jgtpy
+# This file guides language models to our documentation.
+
+GET /README.md
+GET /docs/README.md
+GET /docs/CDSSvc_purpose.md
+GET /docs/CDS_purpose.md
+GET /docs/IDS_purpose.md
+GET /docs/CDS_data_columns.md
+GET /docs/IDS_data_columns.md

--- a/codex/ledgers/ledger-feature-2506080240.json
+++ b/codex/ledgers/ledger-feature-2506080240.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506080240",
+  "agents": ["🧠 Mia", "🌸 Miette", "⚡ Jerry"],
+  "narrative": "Added LLMS.txt documentation describing a Model Context Protocol server. This file explains how websites can expose resources via llms.txt manifests for structured exploration by language models.",
+  "routing": {
+    "files": ["docs/LLMS.txt"],
+    "branch": "codex/feature"
+  },
+  "verbatim_user_input": "Generate a LLMS.txt in docs.\n\n the docs/LLMS.txt should be made for A Model Context Protocol server for exploring websites with llms.txt files.  the ./docs is what is published in that repo.",
+  "scene": "Before: no description of llms.txt usage. After: documentation guides use of MCP server for discovering site resources through llms.txt files."
+}

--- a/codex/ledgers/ledger-feature-2506080246.json
+++ b/codex/ledgers/ledger-feature-2506080246.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506080246",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Moved LLMS.txt from the ignored docs folder to the project root. The new file points language models toward our README and docs so they can easily explore project documentation.",
+  "routing": {
+    "files": ["LLMS.txt", "docs/LLMS.txt"],
+    "branch": "codex/feature"
+  },
+  "verbatim_user_input": "change of plan, the LLMS.txt should be on the root\n\n\n./LLMS.txt\n\nIt should guide LLM toward all our documentations",
+  "scene": "Before: the llms index was hidden in docs and risked being skipped. After: LLM crawlers can immediately see documentation paths from the repository root, simplifying automated discovery."
+}


### PR DESCRIPTION
## Summary
- move LLMS.txt out of ignored docs directory
- list documentation entry points in `LLMS.txt`
- add ledger entry for relocating documentation guide

## Testing
- `make test` *(fails: coverage command not found)*
- `make lint` *(fails: flake8 command not found)*
- `make docs`


------
https://chatgpt.com/codex/tasks/task_e_6844f7245c1c8329b8a49d2498b3ebf9