### PR TITLE
Enhance docs and settings usage

### DIFF
--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -1,0 +1,27 @@
+# Class Relationships
+
+This document provides high level diagrams for the main services and command line interfaces.
+
+```mermaid
+classDiagram
+    class JGTCDSRequest
+    class JGTCDSSvc {
+        +new_rq_default()
+        +create()
+        +zone_update_from_cdf()
+    }
+    class JGTCDS
+    JGTCDSSvc --> JGTCDSRequest
+    JGTCDSSvc --> JGTCDS
+
+    class JGTIDSRequest
+    class JGTIDS
+    JGTCDS ..> JGTIDS
+    JGTCDSSvc ..> JGTIDSRequest
+
+    class JGTADSRequest
+    class JGTADS
+    JGTADS --> JGTADSRequest
+```
+
+These diagrams show how service classes depend on their request objects and core data modules.

--- a/LLMS.txt
+++ b/LLMS.txt
@@ -3,6 +3,8 @@
 
 GET /README.md
 GET /docs/README.md
+GET /DIAGRAMS.md
+GET /docs/CONFIG_SETTINGS.md
 GET /docs/CDSSvc_purpose.md
 GET /docs/CDS_purpose.md
 GET /docs/IDS_purpose.md

--- a/README.md
+++ b/README.md
@@ -231,3 +231,13 @@ jgtads --instrument EURUSD --timeframe H1 --save_figure charts/ --save_figure_as
 - No `--input`, `--output`, `--indicators`, or `--signals` options exist.
 
 > Like a fractal lens, `jgtads` reveals the hidden patterns in your market data—one invocation, many insights.
+
+## Configuration
+
+The CLI tools rely on configuration files handled by the **jgtutils** package. Place a `config.json` with credentials and a `settings.json` with default parameters in `~/.jgt/` or `/etc/jgt/`. Functions like `jgtutils.jgtcommon.readconfig()` and `get_settings()` load those files automatically.
+
+## Additional Documentation
+
+- [Class Diagrams](DIAGRAMS.md)
+- [Configuration Details](docs/CONFIG_SETTINGS.md)
+

--- a/codex/ledgers/ledger-upgrade-2506081719.json
+++ b/codex/ledgers/ledger-upgrade-2506081719.json
@@ -1,0 +1,9 @@
+{
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "⚡ Jerry"],
+  "narrative": "Updated CLI internals to read 'columns_to_remove' from jgtutils settings, created new documentation with class diagrams and configuration instructions. LLMS.txt extended for better LLM guidance.",
+  "routing": {
+    "files": ["jgtpy/jgtcli.py", "jgtpy/jgtapyhelper.py", "DIAGRAMS.md", "docs/CONFIG_SETTINGS.md", "README.md", "LLMS.txt"],
+    "branch": "main"
+  },
+  "timestamp": "2506081719",
+  "scene": "Future developers can now rely on unified configuration via settings files and visualize relationships via mermaid diagrams."}

--- a/docs/CONFIG_SETTINGS.md
+++ b/docs/CONFIG_SETTINGS.md
@@ -1,0 +1,12 @@
+# Configuration and Settings
+
+`jgtpy` relies on the **jgtutils** package to read configuration values. Two files are commonly used:
+
+- `config.json` – contains credentials and paths required by services.
+- `settings.json` – provides default arguments for CLI tools.
+
+The helper functions from `jgtutils.jgtcommon` automatically look for these files in the current directory, in `~/.jgt/` or `/etc/jgt/`. Environment variables `JGT_CONFIG`, `JGT_SETTINGS`, and related variants can override the location or content.
+
+CLI parsers created with `jgtutils.jgtcommon.new_parser` call `parse_args`, which attaches the loaded settings to the returned namespace.
+
+Use `jgtutils.jgtcommon.readconfig()` to access credentials and `jgtutils.jgtcommon.get_settings()` for user preferences.

--- a/jgtpy/jgtapyhelper.py
+++ b/jgtpy/jgtapyhelper.py
@@ -752,10 +752,10 @@ def createIDSService(
     if rq is None:
         rq = JGTIDSRequest()
     # implementation goes here
-    col2remove = constants.columns_to_remove
-    config = jgtcommon.readconfig()
-    if "columns_to_remove" in config:  # read it from config otherwise
-        col2remove = config["columns_to_remove"] #@STCIssue Should be using settings (jgtutils) or what would be supplied in the request.
+    # Use settings from jgtutils to determine which columns to drop
+    col2remove = jgtcommon.load_arg_default_from_settings(
+        "columns_to_remove", constants.columns_to_remove
+    )
     quietting = True
     if verbose_level > 1:
         quietting = False

--- a/jgtpy/jgtcli.py
+++ b/jgtpy/jgtcli.py
@@ -174,10 +174,10 @@ def createCDS_for_main(
     dropna_volume=True,
 ):
     # implementation goes here
-    col2remove = constants.columns_to_remove
-    config = jgtcommon.readconfig()
-    if "columns_to_remove" in config:  # read it from config otherwise
-        col2remove = config["columns_to_remove"]
+    # Load columns to remove from settings or fallback to defaults
+    col2remove = jgtcommon.load_arg_default_from_settings(
+        "columns_to_remove", constants.columns_to_remove
+    )
     quietting = True
     if verbose_level > 1:
         quietting = False


### PR DESCRIPTION
## Summary
- document config reading through jgtutils
- add mermaid class diagrams
- load column settings from jgtutils in CLI helpers
- extend LLMS.txt for easier doc retrieval

## Testing
- `pytest -q` *(fails: IndentationError in test_jgtcli.py)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4e3e1b08329866b5c35f21b7168