### PR TITLE
Add ADS plotting specs and mouth water columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Operating Guide
+
+This repository uses multiple agents to maintain natural-language specifications for the plotting utilities in `jgtpy`. The specs in `./specs` act as the source of truth for future language model implementations.
+
+## Primary Purpose
+- Document the behavior of plotting modules and helper libraries in clear prose so another developer can recreate them in any language.
+- Each specification should describe required data columns, configuration objects, algorithm steps and expected outputs.
+- Specs should be implementation independent: avoid Python-specific details except to clarify data flow or structure.
+
+## Working Rules
+1. When adding or updating code or documentation, also update the corresponding spec file or create a new one under `./specs`.
+2. Summaries in `narrative-map.md` must reflect ongoing work with short glyph cues.
+3. Every commit must include a ledger entry under `codex/ledgers` describing the change, agents involved and the scene unlocked by the new docs.
+4. Run `pytest -q` after modifications to verify that tests still pass.
+
+These notes capture how to proceed with future specification work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,9 @@ This repository uses multiple agents to maintain natural-language specifications
 3. Every commit must include a ledger entry under `codex/ledgers` describing the change, agents involved and the scene unlocked by the new docs.
 4. Run `pytest -q` after modifications to verify that tests still pass.
 
+## Spec Writing Guidelines
+* Treat specs as living documents. Iterate when new behavior emerges or agents suggest clarifications.
+* Use short sentences and bullet lists to describe data fields, configuration options and algorithm steps.
+* Aim for "prose code": enough detail for another developer to reproduce the logic without referencing Python internals.
+
 These notes capture how to proceed with future specification work.

--- a/codex/ledgers/ledger-feature-2506201729.json
+++ b/codex/ledgers/ledger-feature-2506201729.json
@@ -1,0 +1,27 @@
+{
+  "timestamp": "2506201729",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Documented ADS plotting logic and mouth water plotter. Updated CDS column docs to include mouth and water state fields. Added independent specs for cross-language implementation.",
+  "routing": {
+    "files": ["docs/CDS_data_columns.md", "specs/JGTADS.specs.md", "specs/mouth_water_plotter.spec.md", "narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": [
+    "jgtpy/JGTADS.py",
+    "",
+    "that contains python plotting.",
+    "",
+    "We are interested in:",
+    "",
+    "* Analysing the main plot created when we use the main() from jgtpy/JGTADS.py",
+    "* we want a full specifications that is implementation independent of python of all the data that is plotted described in natural language.  docs/IDS_data_columns.md + ./docs/CDS_data_columns.md contains informations on columns (You might not have yet the columns: \"mouth_direction,mouth_phase,bar_position,water_state,mouth_direction_confidence,mouth_phase_confidence\" described, that is coming and are made by : jgtpy/alligator_mouth_water.py).  Note that when we say CDS Data, it derives from IDS Data therefore you have all columns of docs/IDS_data_columns.md + ./docs/CDS_data_columns.md",
+    "* When you created you full specifications for this charting / plotting, you save it into ./specs/JGTADS.specs.md",
+    "* in ./data/current/cds/* (ex. ./data/current/cds/EUR-USD_D1.csv  ) you will observe the CSV data that the jgtpy/JGTADS.py can use to create the charting so you can observe it to make sure you understand fully your analysis.  Your specifications should give us the capabilities to implement with another LLM this charting mecanism into any other language that supports it and should be autonomous of any documentation such as ./docs/CDS_data_columns.md therefore, ensure that your specifications have all the sections they need for that component.  It should have :  plotting logics, the data structure it reads , etc.",
+    "* That might be relevant to create any additional ./specs/<component || service || ...>.spec.md to supplement your work.  (ex. mouth_water_plotter.spec.md for what is in: jgtpy/mouth_water_plotter.py) knowing that many functions create the subplots, they might deserve their own .spec.md",
+    "* columns: \"mouth_direction,mouth_phase,bar_position,water_state,mouth_direction_confidence,mouth_phase_confidence\"  will go into : ./docs/CDS_data_columns.md  so that is a parallel mission to your end-results that we want to achive.",
+    "* Look any git log from that branch to know what the other LLM does if you need to know",
+    "* Make sure your narrative-map.md contains more than just boring commits timeline, add additional columns where you mirror your whole work on various plotting and specifications"
+  ],
+  "scene": "Before: docs lacked mouth water details and the plotter was unspecified. After: cross-language specs and column docs enable independent implementations of ADS charts and mouth water overlays.",
+  "glyphs": "📖🛠️🕊️"
+}

--- a/codex/ledgers/ledger-feature-2506201919.json
+++ b/codex/ledgers/ledger-feature-2506201919.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506201919",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Added agent guide and new specifications for plotting configuration, request handling and mouth water analysis.",
+  "routing": {
+    "files": ["AGENTS.md", "specs/JGTChartConfig.spec.md", "specs/JGTADSRequest.spec.md", "specs/alligator_mouth_water.spec.md", "narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["Great, keep working on the ./specs/* Build your own understanding of what I meant when I tell you to create these specifications based on what is bellow"],
+  "scene": "Before: specs only covered ADS plotting and mouth water plotter. After: clear agent instructions and additional module specs support cross-language use.",
+  "glyphs": "📖🧠🌸"
+}

--- a/codex/ledgers/ledger-feature-2506202018.json
+++ b/codex/ledgers/ledger-feature-2506202018.json
@@ -1,0 +1,15 @@
+{
+  "timestamp": "2506202018",
+  "agents": ["🧠 Mia", "🌸 Miette", "⚡ Jerry"],
+  "narrative": "Refined mouth/water analysis spec with lagging feature notes and operational context. Added new observation loop spec describing CLI and voice workflow. Updated narrative map.",
+  "routing": {
+    "files": [
+      "specs/alligator_mouth_water.spec.md",
+      "specs/observation_loop.spec.md",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "scene": "Specs now guide multi-agent observation loop with lookback awareness, enabling future voice-triggered trading routines.",
+  "user_input": "Codex, please read and reflect on the content stored in: Workspace.jgwill.jgtpy:33.observation-loop.miagem ... We await your transmission."
+}

--- a/codex/ledgers/ledger-feature-2506202033.json
+++ b/codex/ledgers/ledger-feature-2506202033.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506202033",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Refined ADS specification by listing all dataset fields directly so the document stands alone. Updated narrative map to mirror plotting work.",
+  "routing": {
+    "files": ["specs/JGTADS.specs.md", "narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["in specs/JGTADS.specs.md, we see 'It combines all columns documented...' That is important that we are independent of these files"],
+  "scene": "Before: chart spec pointed to other docs. After: full column list enables independent implementation.",
+  "glyphs": "📖🧠🌸"
+}

--- a/codex/ledgers/ledger-feature-2506202122.json
+++ b/codex/ledgers/ledger-feature-2506202122.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506202122",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Documented SpecLang understanding guiding spec work and created definitions file. Updated narrative map accordingly.",
+  "routing": {
+    "files": ["docs/DEFINITIONS.md", "narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["in DEFINITIONS.md write a section \"## SPECLANG\" where you descride your definition of what SpecLang is for you and how that is guiding the work you are doing in ./specs/*.spec.md"],
+  "scene": "Before: project lacked spec approach description. After: SpecLang section clarifies natural language specifications for cross-language plotting.",
+  "glyphs": "📖🧠🌸"
+}

--- a/codex/ledgers/ledger-feature-2506202143.json
+++ b/codex/ledgers/ledger-feature-2506202143.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506202143",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Refined spec documents and agent guide using SpecLang principles. Added output sections and ordering notes for plotting specs. Updated narrative map with spec overview table.",
+  "routing": {
+    "files": ["docs/DEFINITIONS.md", "AGENTS.md", "specs/JGTADS.specs.md", "specs/alligator_mouth_water.spec.md", "specs/mouth_water_plotter.spec.md", "specs/observation_loop.spec.md", "narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["Great, given what you wrote in : docs/DEFINITIONS.md you will review each of your ./specs/*"],
+  "scene": "Before: specs lacked explicit guidance from SpecLang. After: clarified documents and new spec overview help future agents implement plotting modules consistently.",
+  "glyphs": "📖🧠🌸"
+}

--- a/codex/ledgers/ledger-feature-2506202157.json
+++ b/codex/ledgers/ledger-feature-2506202157.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506202157",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Inserted 'Recent Awareness' section into narrative map describing how SpecLang specs and observation loops shift workflow. Documentation is seen as living conversation.",
+  "routing": {
+    "files": ["narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["Your narrative-map.md should really have a section on that new awareness you just had"],
+  "scene": "Before: timeline ended at spec overview. After: new awareness section highlights iterative spec approach guiding CLI and voice agents.",
+  "glyphs": "📖🧠🌸"
+}

--- a/docs/CDS_data_columns.md
+++ b/docs/CDS_data_columns.md
@@ -22,3 +22,9 @@
 | `mfi_val` | The MFI value. |
 | `zone_signal` | The zone signal value. |
 | `zone_int` | The zone integer value. |
+| `mouth_direction` | The direction of the Alligator mouth (buy, sell, or neither). |
+| `mouth_phase` | The phase of the Alligator mouth (opening, open, closing, sleeping, or none). |
+| `bar_position` | The position of the bar relative to the Alligator mouth (above, in, or below). |
+| `water_state` | The water classification derived from mouth behavior (splashing, eating, throwing, poping, entering, switching, sleeping). |
+| `mouth_direction_confidence` | Confidence score for the mouth direction calculation. |
+| `mouth_phase_confidence` | Confidence score for the mouth phase calculation. |

--- a/docs/DEFINITIONS.md
+++ b/docs/DEFINITIONS.md
@@ -13,3 +13,9 @@ Working with SpecLang guides us to:
 - Maintain the specs in lockstep with code changes so new agents always understand the expected behavior.
 
 This approach allows multiple language implementations or AI agents to share the same understanding of the plotting services built here.
+
+Additional points distilled from the SpecLang research prototype:
+
+- Specs evolve through an iterative feedback loop where running code informs new sections or clarifies ambiguous behavior.
+- Natural language is used as "prose code": concise yet precise instructions that assume a programmer's mindset.
+- The model may suggest refinements, so treat the spec as a conversation rather than a static document.

--- a/docs/DEFINITIONS.md
+++ b/docs/DEFINITIONS.md
@@ -1,0 +1,15 @@
+# Definitions
+
+This document collects recurring terms and concepts used across the project.
+
+## SPECLANG
+
+SpecLang refers to a natural-language specification approach championed by GitHub Next.  In this repository it means our specs under `./specs` are treated as the primary source of truth for plotting behavior.  Each spec should be precise enough that an LLM or developer can implement the described logic in any programming language without referring back to the Python code.
+
+Working with SpecLang guides us to:
+
+- Describe data columns, configuration objects and algorithm steps in straightforward prose.
+- Keep plotting details implementation agnostic while noting necessary calculations or relationships.
+- Maintain the specs in lockstep with code changes so new agents always understand the expected behavior.
+
+This approach allows multiple language implementations or AI agents to share the same understanding of the plotting services built here.

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -15,7 +15,8 @@
 
 These changes allow passing `-new` and `-old` simultaneously without argparse errors. The parsers now use a relaxed helper so jgtapp can default to fresh when needed.
 - a7bacdf: verify CLI compatibility and tests pass
-\n- <pending>: documented JGTADS plotting and mouth water modules; added new data columns specs.
+- 5c5b651: documented JGTADS plotting and mouth water modules; added new data columns specs.
 
-- <pending2>: added operational guide for agents and expanded specs for chart config, request object and mouth/water analysis
-- <pending3>: refine mouth/water spec with lookback notes and operational context; create observation loop spec
+- d54bb49: added operational guide for agents and expanded specs for chart config, request object and mouth/water analysis
+- 4b38cdb: refine mouth/water spec with lookback notes and operational context; create observation loop spec
+- <newcommit>: refine dataset column definitions in ADS spec

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -19,4 +19,5 @@ These changes allow passing `-new` and `-old` simultaneously without argparse er
 
 - d54bb49: added operational guide for agents and expanded specs for chart config, request object and mouth/water analysis
 - 4b38cdb: refine mouth/water spec with lookback notes and operational context; create observation loop spec
-- <newcommit>: refine dataset column definitions in ADS spec
+- fb667b9: refine dataset column definitions in ADS spec
+- d11c7c5: document SpecLang definition

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -33,3 +33,7 @@ These changes allow passing `-new` and `-old` simultaneously without argparse er
 | `alligator_mouth_water.spec.md` | Explains how mouth and water states are computed. |
 | `mouth_water_plotter.spec.md` | Outlines overlay creation for mouth/water annotations. |
 | `observation_loop.spec.md` | Summarizes the CLI-driven analysis and voice workflow. |
+
+## Recent Awareness
+
+Through iterative spec work we realized the documentation itself drives new workflows. The observation loop shows how CLI triggers and voice analysis combine with SpecLang specs to shape trading decisions. Each plotter spec now stands alone so any language can reproduce ADS visuals. This awareness strengthens the repo as a living conversation rather than static code.

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -15,3 +15,4 @@
 
 These changes allow passing `-new` and `-old` simultaneously without argparse errors. The parsers now use a relaxed helper so jgtapp can default to fresh when needed.
 - a7bacdf: verify CLI compatibility and tests pass
+\n- <pending>: documented JGTADS plotting and mouth water modules; added new data columns specs.

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -21,3 +21,15 @@ These changes allow passing `-new` and `-old` simultaneously without argparse er
 - 4b38cdb: refine mouth/water spec with lookback notes and operational context; create observation loop spec
 - fb667b9: refine dataset column definitions in ADS spec
 - d11c7c5: document SpecLang definition
+- aa273be: applying previous commit introducing more specs and CDS column updates
+
+## Spec Overview
+
+| Spec File | Purpose |
+|-----------|---------|
+| `JGTADS.specs.md` | Describes the multi-panel ADS chart plotting steps and dataset columns. |
+| `JGTADSRequest.spec.md` | Defines the request object controlling ADS plotting. |
+| `JGTChartConfig.spec.md` | Lists configuration fields for customizing ADS plots. |
+| `alligator_mouth_water.spec.md` | Explains how mouth and water states are computed. |
+| `mouth_water_plotter.spec.md` | Outlines overlay creation for mouth/water annotations. |
+| `observation_loop.spec.md` | Summarizes the CLI-driven analysis and voice workflow. |

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -16,3 +16,5 @@
 These changes allow passing `-new` and `-old` simultaneously without argparse errors. The parsers now use a relaxed helper so jgtapp can default to fresh when needed.
 - a7bacdf: verify CLI compatibility and tests pass
 \n- <pending>: documented JGTADS plotting and mouth water modules; added new data columns specs.
+
+- <pending2>: added operational guide for agents and expanded specs for chart config, request object and mouth/water analysis

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -18,3 +18,4 @@ These changes allow passing `-new` and `-old` simultaneously without argparse er
 \n- <pending>: documented JGTADS plotting and mouth water modules; added new data columns specs.
 
 - <pending2>: added operational guide for agents and expanded specs for chart config, request object and mouth/water analysis
+- <pending3>: refine mouth/water spec with lookback notes and operational context; create observation loop spec

--- a/specs/JGTADS.specs.md
+++ b/specs/JGTADS.specs.md
@@ -74,6 +74,9 @@ Additional subplots are only rendered if the corresponding `JGTChartConfig` flag
 
 - `JGTChartConfig` controls which overlays appear. Disabling AO hides the AO panel and shifts AC up.
 - The mouth/water annotations rely on analysis results from `alligator_mouth_water.py`. If those columns are absent, the plot is generated without them.
-- The plotting code expects data sorted by ascending datetime with no gaps.
+ - The plotting code expects data sorted by ascending datetime with no gaps.
+
+## Output
+The plotting routine returns a figure object, the associated axes list and the clipped dataset used for the plot. Implementations may instead stream the figure to a web interface or save it to disk depending on the request settings.
 
 This specification allows implementing an equivalent chart generator in another environment while keeping behavior consistent with the Python version.

--- a/specs/JGTADS.specs.md
+++ b/specs/JGTADS.specs.md
@@ -1,0 +1,49 @@
+# JGTADS Charting Specification
+
+This document describes the plotting logic of `JGTADS.py` in implementation independent terms. It outlines the required data columns and how they are used to build each subplot so another language can reproduce the same visuals.
+
+## Required Data Structure
+
+The input is a tabular dataset (CSV or DataFrame) produced by the CDS service. It combines all columns documented in `IDS_data_columns.md` and `CDS_data_columns.md`. Key fields used by the charting routine are:
+
+- **OHLC columns**: `Open`, `High`, `Low`, `Close` (price series for candlesticks).
+- **Alligator lines**: `jaw`, `teeth`, `lips`.
+- **Fractals**: `fh`, `fl` plus optional degree variants `fh<n>` and `fl<n>` where `<n>` indicates fractal degree (e.g. `fh8`).
+- **FDB signals**: `fdb`, `fdbb`, `fdbs`.
+- **AO/AC oscillators**: `ao`, `ac`.
+- **Saucer and peak markers**: `sb`, `ss`, `price_peak_above`, `price_peak_bellow`, `ao_peak_above`, `ao_peak_bellow`.
+- **Zone information**: `zcol`, `zlc`, `zlcB`, `zlcS`.
+- **Mouth/Water state**: `mouth_direction`, `mouth_phase`, `bar_position`, `water_state`, `mouth_direction_confidence`, `mouth_phase_confidence`.
+
+All rows are indexed by date/time which is converted to the appropriate format depending on timeframe.
+
+## Plot Layout
+
+The routine builds a multi‑panel figure using mplfinance:
+
+1. **Main panel** – OHLC bars and overlays.
+   - Candles are colored by `zcol` (zone color).
+   - Alligator lines (`jaw`, `teeth`, `lips`) are drawn as separate lines.
+   - Fractal markers (regular, higher degree, and ultra) are plotted using the `fh*` and `fl*` columns with slight vertical offsets.
+   - Divergent bar signals (`fdbb` and `fdbs`) appear as scatter markers above or below the bar.
+   - Price peak markers and mouth water annotations (from `mouth_*` columns) can be added when enabled.
+2. **AO panel** – Awesome Oscillator bar chart with optional saucer signals and AO peak markers.
+3. **AC panel** – Acceleration/Deceleration Oscillator bar chart with optional AC buy/sell markers.
+
+Additional subplots are only rendered if the corresponding `JGTChartConfig` flags are true. The figure title shows the instrument and timeframe with a subtitle displaying the last bar time and bar count.
+
+## Plotting Steps
+
+1. **Data Selection**: keep the latest `nb_bar_on_chart` rows from the dataset so the plot window size matches the chart config.
+2. **Color/offset calculations**: dynamic offsets are computed from average bar height to place markers above or below candles without overlap. AO and AC colors depend on bar-to-bar delta.
+3. **Addplots construction**: each optional indicator produces one or more `addplot` objects describing scatter or line series. These are accumulated and supplied to `mpf.plot`.
+4. **Figure decoration**: after plotting, the subtitle, axis limits, and grid settings are adjusted. Future bars space is added on the right.
+5. **Saving and display**: figures can be saved to disk or displayed on screen based on the request flags.
+
+## Usage Notes
+
+- `JGTChartConfig` controls which overlays appear. Disabling AO hides the AO panel and shifts AC up.
+- The mouth/water annotations rely on analysis results from `alligator_mouth_water.py`. If those columns are absent, the plot is generated without them.
+- The plotting code expects data sorted by ascending datetime with no gaps.
+
+This specification allows implementing an equivalent chart generator in another environment while keeping behavior consistent with the Python version.

--- a/specs/JGTADS.specs.md
+++ b/specs/JGTADS.specs.md
@@ -4,16 +4,46 @@ This document describes the plotting logic of `JGTADS.py` in implementation inde
 
 ## Required Data Structure
 
-The input is a tabular dataset (CSV or DataFrame) produced by the CDS service. It combines all columns documented in `IDS_data_columns.md` and `CDS_data_columns.md`. Key fields used by the charting routine are:
+The input is a tabular dataset (CSV or DataFrame) produced by the CDS service. It contains price series, indicator lines and numerous derived signals used for plotting.
 
-- **OHLC columns**: `Open`, `High`, `Low`, `Close` (price series for candlesticks).
-- **Alligator lines**: `jaw`, `teeth`, `lips`.
-- **Fractals**: `fh`, `fl` plus optional degree variants `fh<n>` and `fl<n>` where `<n>` indicates fractal degree (e.g. `fh8`).
-- **FDB signals**: `fdb`, `fdbb`, `fdbs`.
-- **AO/AC oscillators**: `ao`, `ac`.
-- **Saucer and peak markers**: `sb`, `ss`, `price_peak_above`, `price_peak_bellow`, `ao_peak_above`, `ao_peak_bellow`.
-- **Zone information**: `zcol`, `zlc`, `zlcB`, `zlcS`.
-- **Mouth/Water state**: `mouth_direction`, `mouth_phase`, `bar_position`, `water_state`, `mouth_direction_confidence`, `mouth_phase_confidence`.
+### Price and Volume
+- `Date` – timestamp of each bar
+- `BidOpen`, `BidHigh`, `BidLow`, `BidClose` – raw bid prices
+- `AskOpen`, `AskHigh`, `AskLow`, `AskClose` – raw ask prices
+- `Open`, `High`, `Low`, `Close` – consolidated OHLC values
+- `Volume` – tick volume
+- `Median` – midpoint of High and Low
+
+### Core Indicators
+- `ao` – Awesome Oscillator
+- `ac` – Acceleration/Deceleration Oscillator
+- `jaw`, `teeth`, `lips` – Alligator lines
+- `bjaw`, `bteeth`, `blips` – baseline Alligator averages
+- `tjaw`, `tteeth`, `tlips` – trailing Alligator averages
+- `mfi` – Market Facilitation Index
+
+### Fractal Levels
+- `fh`, `fl` – base fractal highs and lows
+- `fh3`, `fl3`, `fh5`, `fl5`, `fh8`, `fl8`, `fh13`, `fl13`, `fh21`, `fl21`, `fh34`, `fl34`, `fh55`, `fl55`, `fh89`, `fl89` – higher degree fractals
+
+### Signals and Zones
+- `fdb`, `fdbb`, `fdbs` – fractal divergent bar signals
+- `aoaz`, `aobz` – AO zone classification
+- `zlc`, `zlcb`, `zlcs` – zero line cross values
+- `zcol` – zone color
+- `zone_sig` – zone signal label
+- `bz`, `sz` – buy and sell zone flags
+- `acs`, `acb` – AC oscillator buy/sell markers
+- `ss`, `sb` – saucer sell/buy markers
+- `price_peak_above`, `price_peak_bellow` – price peak markers
+- `ao_peak_above`, `ao_peak_bellow` – AO peak markers
+
+### Mouth/Water States
+- `mouth_direction`, `mouth_phase`, `bar_position`, `water_state`
+- `mouth_direction_confidence`, `mouth_phase_confidence`
+
+### Additional MFI Metrics
+- `mfi_sq`, `mfi_green`, `mfi_fade`, `mfi_fake`, `mfi_sig`, `mfi_str`
 
 All rows are indexed by date/time which is converted to the appropriate format depending on timeframe.
 

--- a/specs/JGTADSRequest.spec.md
+++ b/specs/JGTADSRequest.spec.md
@@ -1,0 +1,19 @@
+# JGTADSRequest Specification
+
+`JGTADSRequest` represents a plotting request. It extends `JGTCDSRequest` to fetch data and holds a `JGTChartConfig` instance.
+
+## Important Fields
+- **instrument** and **timeframe**: Identifiers for the dataset to plot.
+- **cc**: Embedded `JGTChartConfig` controlling plot appearance.
+- **tlid_range**: Optional bar range selection when plotting events.
+- **nb_bar_on_chart**, **cds_required_amount_of_bar_for_calc**, **nb_bar_to_retrieve**: Mirrored from the config but can be overridden in the request constructor.
+- **save_additional_figures_path** / **save_additional_figures_dpi**: Where to store images when requested.
+- **show_feature_one_plot**, **show_plain_plot**, etc.: Convenience flags passed to `cc` so presets can be chosen directly when building requests.
+- **plot_ao_peaks** and **show**: Additional runtime parameters for `JGTADS` plotting functions.
+
+## Behavior
+Creating a new request with `new_feature_plot(instrument, timeframe, feature_plot)` builds an appropriate `JGTChartConfig` using `JGTChartConfig.new_feature_plot` and attaches it to the request.
+
+Calling `reset()` synchronizes fields from `cc` back to the request for backward compatibility.
+
+This object is typically fed into `jgtxplot18c_231209` or other ADS routines where it governs data selection and plotting behavior.

--- a/specs/JGTChartConfig.spec.md
+++ b/specs/JGTChartConfig.spec.md
@@ -1,0 +1,23 @@
+# JGTChartConfig Specification
+
+This configuration object controls how ADS charts are rendered. Another language can reproduce ADS visuals by respecting the fields described here.
+
+## Key Parameters
+- **nb_bar_on_chart**: Number of bars to display in the main window.
+- **cds_required_amount_of_bar_for_calc**: Minimum history needed for indicator calculations.
+- **show_ao, show_ac**: Toggle AO and AC panels. When AO is disabled, AC shifts to the second panel.
+- **show_fractal**, **show_fractal_higher**, **show_fractal_ultra_higher**: Enable different fractal levels.
+- **show_fdb_signal**: Display divergent bar markers.
+- **show_price_peak**, **show_saucer**, **show_ao_peaks**: Additional signal overlays.
+- **show_alligator**: Plot Alligator lines.
+- **show_zlc**: Show zero line cross data on the AO panel.
+- **plot_style**: mplfinance style name (e.g. "yahoo").
+- **main_plot_type**: Candle or ohlc bar type.
+- **marker sizes and colors**: Many attributes define marker size and color for each indicator. These should map directly to plotting library styles.
+
+## Behavior
+Calling `update()` adjusts dependent flags so that feature presets like `show_plain_plot` or `show_feature_one_plot` alter multiple other options. Implementations should replicate this logic when applying presets.
+
+`new_feature_plot(feature_plot)` returns a preconfigured instance for demo charts. Feature 1 enables higher fractals and FDB signals; feature 3 focuses on AC indicators, etc.
+
+The configuration is typically accessed via `JGTADSRequest.cc` but can also be used standalone.

--- a/specs/alligator_mouth_water.spec.md
+++ b/specs/alligator_mouth_water.spec.md
@@ -1,0 +1,28 @@
+# Alligator Mouth Water Analysis Specification
+
+This module derives additional state columns from CDS data. It classifies the Alligator indicator's mouth behavior and price interaction.
+
+## Inputs
+The analyzer requires sequences of:
+- `jaw`, `teeth`, `lips` values representing the Alligator lines
+- `High` and `Low` prices for each bar
+- `ao` oscillator values (optional but used for water state)
+
+## Output Columns
+After processing, the following columns are appended to the dataframe:
+- `mouth_direction`: `buy`, `sell` or `neither`
+- `mouth_phase`: `opening`, `open`, `closing`, `sleeping`, `none`
+- `bar_position`: location of the bar relative to the mouth (`above`, `in`, `below`)
+- `water_state`: activity classification such as `splashing`, `eating`, `throwing`, `poping`, `entering`, `switching`, `sleeping`
+- `mouth_direction_confidence`: score between 0 and 1 for the direction calculation
+- `mouth_phase_confidence`: score between 0 and 1 for the phase calculation
+- `state_transition`: boolean marking when any of the states change
+
+## Algorithm Highlights
+1. **Mouth Direction** – Uses slope and line ordering of the three Alligator lines to decide buy/sell/neither. Confidence increases with separation and slope magnitude.
+2. **Mouth Phase** – Evaluates the distance between lines or optionally a Gator Oscillator to decide whether the mouth is opening, open, closing or sleeping.
+3. **Bar Position** – Compares the bar's high/low to the line extremes to decide above/in/below.
+4. **Water State** – Combines direction, phase, and bar position with AO momentum to produce the water activity state. Transition detection compares with the previous bar state.
+
+## Usage
+`analyze_dataframe(df)` attaches these columns to a CDS dataframe. The results are consumed by `mouth_water_plotter` and ADS plotting routines.

--- a/specs/alligator_mouth_water.spec.md
+++ b/specs/alligator_mouth_water.spec.md
@@ -8,6 +8,14 @@ The analyzer requires sequences of:
 - `High` and `Low` prices for each bar
 - `ao` oscillator values (optional but used for water state)
 
+### Lookback Considerations
+The analyzer inspects at least the last two bars to calculate slopes and
+distances. Some trading setups may require additional **lagging features** from
+earlier bars (for example three or more periods back) to confirm transitions.
+The `lookback_periods` setting controls this history window and defaults to
+**3**. Voice or CLI workflows may extend this lookback if deeper context proves
+useful.
+
 ## Output Columns
 After processing, the following columns are appended to the dataframe:
 - `mouth_direction`: `buy`, `sell` or `neither`
@@ -25,4 +33,12 @@ After processing, the following columns are appended to the dataframe:
 4. **Water State** – Combines direction, phase, and bar position with AO momentum to produce the water activity state. Transition detection compares with the previous bar state.
 
 ## Usage
-`analyze_dataframe(df)` attaches these columns to a CDS dataframe. The results are consumed by `mouth_water_plotter` and ADS plotting routines.
+`analyze_dataframe(df)` attaches these columns to a CDS dataframe. The results
+are consumed by `mouth_water_plotter` and ADS plotting routines.
+
+## Operational Context
+CLI tools schedule this analysis periodically (e.g. every five minutes) and feed
+the enriched dataset into plotting or voice-based inspection loops. During a
+time-boxed observation window—usually around ninety seconds—an agent describes
+the latest mouth and water states in natural language. These descriptions map
+back into programmatic triggers for trading decisions or alerts.

--- a/specs/alligator_mouth_water.spec.md
+++ b/specs/alligator_mouth_water.spec.md
@@ -33,8 +33,10 @@ After processing, the following columns are appended to the dataframe:
 4. **Water State** – Combines direction, phase, and bar position with AO momentum to produce the water activity state. Transition detection compares with the previous bar state.
 
 ## Usage
-`analyze_dataframe(df)` attaches these columns to a CDS dataframe. The results
-are consumed by `mouth_water_plotter` and ADS plotting routines.
+`analyze_dataframe(df)` attaches these columns to a CDS dataframe. The input
+should be sorted by ascending date with no gaps so that slope calculations are
+consistent. The results are consumed by `mouth_water_plotter` and ADS plotting
+routines.
 
 ## Operational Context
 CLI tools schedule this analysis periodically (e.g. every five minutes) and feed

--- a/specs/mouth_water_plotter.spec.md
+++ b/specs/mouth_water_plotter.spec.md
@@ -1,0 +1,41 @@
+# Mouth Water Plotter Specification
+
+This specification captures the behavior of `mouth_water_plotter.py`. The module visualizes the Alligator mouth state analysis produced by `alligator_mouth_water.py`.
+
+## Data Requirements
+
+The plotter expects the CDS dataset to include the following columns for each bar:
+
+- `mouth_direction` – buy, sell or neither.
+- `mouth_phase` – opening, open, closing, sleeping, none.
+- `bar_position` – relative location of the bar to the mouth: above, in or below.
+- `water_state` – classified price action: splashing, eating, throwing, poping, entering, switching or sleeping.
+- `mouth_direction_confidence` – confidence score of the direction estimate.
+- `mouth_phase_confidence` – confidence score of the phase estimate.
+
+OHLC columns (`High`, `Low`) are also needed for placing markers.
+
+## Plot Outputs
+
+The plotter can produce two kinds of output:
+
+1. **Addplots for integration with JGTADS** – `create_mouth_water_addplots` returns a list of mplfinance `addplot` objects representing water state and mouth direction symbols overlaid on the main chart. A special highlight is drawn for the last completed bar.
+2. **Standalone analysis charts** – `create_specialized_mouth_water_chart` can generate dedicated views such as a states timeline, last state analysis, or a combined zone/state visualization.
+
+## Symbol Mapping
+
+Markers are selected according to configuration:
+
+- Water states map to colored symbols or emojis (fallback to ASCII for compatibility).
+- Mouth direction uses triangle markers; bar position uses triangles or squares.
+- Colors reflect buy/sell/neutral interpretation.
+
+Marker sizes and offsets are configurable via `MouthWaterPlotConfig`.
+
+## Workflow
+
+1. Instantiate `MouthWaterPlotter` with optional configuration.
+2. Call `create_mouth_water_addplots(data, panel_id)` to get overlays for the main ADS plot.
+3. Optional: use `create_specialized_mouth_water_chart` for more detailed standalone visuals or CLI output.
+
+These steps allow any implementation to reproduce the same overlay and analysis charts using the data columns described above.

--- a/specs/mouth_water_plotter.spec.md
+++ b/specs/mouth_water_plotter.spec.md
@@ -37,5 +37,6 @@ Marker sizes and offsets are configurable via `MouthWaterPlotConfig`.
 1. Instantiate `MouthWaterPlotter` with optional configuration.
 2. Call `create_mouth_water_addplots(data, panel_id)` to get overlays for the main ADS plot.
 3. Optional: use `create_specialized_mouth_water_chart` for more detailed standalone visuals or CLI output.
+   Ensure the input dataset is ordered by time so markers appear in the correct sequence.
 
 These steps allow any implementation to reproduce the same overlay and analysis charts using the data columns described above.

--- a/specs/observation_loop.spec.md
+++ b/specs/observation_loop.spec.md
@@ -1,0 +1,26 @@
+# Observation Loop Specification
+
+This document outlines the recurring workflow used by CLI agents and voice
+interfaces to evaluate ADS charts and trading states.
+
+## Overview
+1. **Data Refresh** – Every few minutes a CLI agent pulls the latest CDS data and
+   runs analysis modules such as `alligator_mouth_water`.
+2. **Chart Generation** – The enriched dataset is plotted using `JGTADS` and
+   overlay modules. Figures may be saved or sent to a display service.
+3. **Voice Inspection Window** – A companion voice agent opens a short
+   observation window (about 90 seconds). It reads current states from the plot
+   or the data and describes key movements in natural language.
+4. **Trigger Evaluation** – Spoken or textual descriptions are mapped back to
+   programmatic rules. If conditions are met, the CLI agent issues trading
+   actions or alerts.
+
+## Data Contract
+The loop expects the full CDS data columns, including the mouth and water state
+fields described in `alligator_mouth_water.spec.md`.
+
+## Extensibility
+Future agents may adjust the refresh rate, include additional indicators or use
+longer historical lookback windows to refine predictions.  Specifications should
+remain modular so that each analysis or plotting step can be replaced without
+breaking the loop.

--- a/specs/observation_loop.spec.md
+++ b/specs/observation_loop.spec.md
@@ -5,7 +5,8 @@ interfaces to evaluate ADS charts and trading states.
 
 ## Overview
 1. **Data Refresh** – Every few minutes a CLI agent pulls the latest CDS data and
-   runs analysis modules such as `alligator_mouth_water`.
+   runs analysis modules such as `alligator_mouth_water`. The dataset must remain
+   sorted chronologically so subsequent plots align with voice commentary.
 2. **Chart Generation** – The enriched dataset is plotted using `JGTADS` and
    overlay modules. Figures may be saved or sent to a display service.
 3. **Voice Inspection Window** – A companion voice agent opens a short


### PR DESCRIPTION
## Summary
- document JGTADS plotting features
- describe mouth water plotter module
- extend CDS data column docs with mouth/water fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855997cab70832980e80e5497dde926