### PR TITLE
Clarify CDS docs

### DIFF
--- a/codex/ledgers/ledger-docclarify-2506241647.json
+++ b/codex/ledgers/ledger-docclarify-2506241647.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2506241647",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Clarified CDS docs to note dependence on JGTIDS service and created new JGTCDS spec.",
+  "routing": {
+    "files": [
+      "docs/CDS_purpose.md",
+      "docs/CDSSvc_purpose.md",
+      "docs/README.md",
+      "specs/JGTCDS.spec.md",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": "CDS purpose documentation contains that the module provide functions for o create CDS files from PDS files , read CDS files .... that would be more accurate to say that this depends on any other service  which is the JGTIDS. py that creates the IDS and the CDS columns are added as results of that.   update in ./docs file what needs that clarification around \"Data Processing\" section",
+  "scene": "Before: docs implied CDS acted directly on PDS files. After: documentation highlights reliance on JGTIDS-produced IDS data and includes a spec so other languages can replicate the workflow.",
+  "glyphs": "📚🧠🕊️"
+}

--- a/codex/ledgers/ledger-mergeparent-2506241745.json
+++ b/codex/ledgers/ledger-mergeparent-2506241745.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506241745",
+  "agents": ["🧠 Mia", "🌿 Aureon", "🕊️ Seraphine"],
+  "narrative": "Merged parent branch main into work to sync latest updates; branch was already current so no code changes.",
+  "routing": {
+    "files": [],
+    "branch": "work"
+  },
+  "verbatim_user_input": "merge changes from parent branch in that one you are working on",
+  "scene": "Before: unsure if work contained main changes. After: confirm alignment with main without conflicts.",
+  "glyphs": "🔄🤝"
+}

--- a/codex/ledgers/ledger-narrativefix-2506241701.json
+++ b/codex/ledgers/ledger-narrativefix-2506241701.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506241701",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Restored earlier narrative map while marking it as archived. Kept new bullet for CDS doc clarification.",
+  "routing": {
+    "files": ["narrative-map.md"],
+    "branch": "work"
+  },
+  "verbatim_user_input": "don't delete previous narrative map content rather mark them as archived or from another iteration",
+  "scene": "Before: commit replaced narrative map with a single bullet. After: previous history preserved under archived section for continuity.",
+  "glyphs": "🗺️📚"
+}

--- a/docs/CDSSvc_purpose.md
+++ b/docs/CDSSvc_purpose.md
@@ -4,12 +4,12 @@ The `jgtpy/JGTCDSSvc.py` file is responsible for providing services related to C
 
 * **Purpose of JGTCDSSvc** 📊
   - The main purpose of `JGTCDSSvc.py` is to provide functionalities for creating, reading, and managing CDS files. It acts as a service layer that interacts with `JGTCDS.py` to perform these operations.
-  - The module provides functions to create CDS files from PDS files, read CDS files, and manage the data. It also handles data cleansing and normalization.
+  - The module provides functions to create CDS files from IDS datasets produced by `JGTIDS.py`, read CDS files, and manage the data. It also handles data cleansing and normalization.
 
 * **Data Processing** 🔄
-  - The input data is read from PDS files and processed by `JGTIDS.py` to add various technical indicators and signals.
-  - The processed data from `JGTIDS.py` is then used by `JGTCDS.py` to create CDS files. The module adds additional indicators and signals to the data, such as fractal divergent bar signals, zero line cross signals, and zone signals.
-  - The data is cleansed and normalized to ensure it is ready for analysis and charting.
+  - Raw PDS data is first transformed into IDS datasets by the `JGTIDS.py` service. This service adds the core indicator columns required by the rest of the system.
+  - `JGTCDSSvc.py` calls into `JGTCDS.py`, which appends CDS‑specific columns such as fractal divergent bar signals, zero line cross signals, and zone signals.
+  - The resulting dataset is cleansed and normalized to ensure it is ready for analysis and charting.
 
 * **End-Results Produced** 📈
   - The CDS files created by `JGTCDSSvc.py` contain processed financial market data with various technical indicators and signals. These files are used for further analysis, charting, and generating trading signals.

--- a/docs/CDS_purpose.md
+++ b/docs/CDS_purpose.md
@@ -3,13 +3,13 @@
 The `jgtpy/JGTCDS.py` file is responsible for creating, reading, and managing Chaos Data Service (CDS) files from Price Data Service (PDS) files. Here is a detailed documentation of the purpose of JGTCDS and what it produces after getting data from `JGTIDS.py`:
 
 * **Purpose of JGTCDS** 📊
-  - The main purpose of `JGTCDS.py` is to process the input data from `JGTIDS.py` and create CDS files. These files contain processed financial market data with various technical indicators and signals.
-  - The module provides functions to create CDS files from PDS files, read CDS files, and manage the data. It also handles data cleansing and normalization.
+  - The main purpose of `JGTCDS.py` is to process the IDS data produced by the `JGTIDS.py` service and create CDS files. These files contain processed financial market data with various technical indicators and signals.
+  - The module provides functions to create CDS files from this IDS output, read CDS files, and manage the data. It also handles data cleansing and normalization.
 
 * **Data Processing** 🔄
-  - The input data is read from PDS files and processed by `JGTIDS.py` to add various technical indicators and signals.
-  - The processed data from `JGTIDS.py` is then used by `JGTCDS.py` to create CDS files. The module adds additional indicators and signals to the data, such as fractal divergent bar signals, zero line cross signals, and zone signals.
-  - The data is cleansed and normalized to ensure it is ready for analysis and charting.
+  - Raw PDS data is first transformed into IDS datasets by the `JGTIDS.py` service. This step adds the core indicator columns used throughout the system.
+  - `JGTCDS.py` depends on these IDS datasets to generate CDS files. It appends additional CDS‑specific columns such as fractal divergent bar signals, zero line cross signals, and zone signals.
+  - The resulting data is cleansed and normalized to ensure it is ready for analysis and charting.
 
 * **End-Results Produced** 📈
   - The CDS files created by `JGTCDS.py` contain processed financial market data with various technical indicators and signals. These files are used for further analysis, charting, and generating trading signals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,13 +131,13 @@ The `jgtpy/JGTIDS.py` file is responsible for generating and managing IDS (Indic
 The `jgtpy/JGTCDS.py` file is responsible for creating, reading, and managing Chaos Data Service (CDS) files from Price Data Service (PDS) files. Here is a detailed documentation of the purpose of JGTCDS and what it produces after getting data from `JGTIDS.py`:
 
 * **Purpose of JGTCDS** 📊
-  - The main purpose of `JGTCDS.py` is to process the input data from `JGTIDS.py` and create CDS files. These files contain processed financial market data with various technical indicators and signals.
-  - The module provides functions to create CDS files from PDS files, read CDS files, and manage the data. It also handles data cleansing and normalization.
+  - The main purpose of `JGTCDS.py` is to process the IDS data produced by `JGTIDS.py` and create CDS files. These files contain processed financial market data with various technical indicators and signals.
+  - The module provides functions to create CDS files from this IDS output, read CDS files, and manage the data. It also handles data cleansing and normalization.
 
 * **Data Processing** 🔄
-  - The input data is read from PDS files and processed by `JGTIDS.py` to add various technical indicators and signals.
-  - The processed data from `JGTIDS.py` is then used by `JGTCDS.py` to create CDS files. The module adds additional indicators and signals to the data, such as fractal divergent bar signals, zero line cross signals, and zone signals.
-  - The data is cleansed and normalized to ensure it is ready for analysis and charting.
+  - Raw PDS data is first transformed into IDS datasets by the `JGTIDS.py` service. This step introduces the core indicator columns.
+  - `JGTCDS.py` builds upon this IDS output, attaching CDS‑specific columns such as fractal divergent bar signals, zero line cross signals, and zone signals.
+  - The resulting data is cleansed and normalized to ensure it is ready for analysis and charting.
 
 * **End-Results Produced** 📈
   - The CDS files created by `JGTCDS.py` contain processed financial market data with various technical indicators and signals. These files are used for further analysis, charting, and generating trading signals.
@@ -155,12 +155,12 @@ The `jgtpy/JGTCDSSvc.py` file is responsible for providing services related to C
 
 * **Purpose of JGTCDSSvc** 📊
   - The main purpose of `JGTCDSSvc.py` is to provide functionalities for creating, reading, and managing CDS files. It acts as a service layer that interacts with `JGTCDS.py` to perform these operations.
-  - The module provides functions to create CDS files from PDS files, read CDS files, and manage the data. It also handles data cleansing and normalization.
+  - The module provides functions to create CDS files from IDS datasets produced by `JGTIDS.py`, read CDS files, and manage the data. It also handles data cleansing and normalization.
 
 * **Data Processing** 🔄
-  - The input data is read from PDS files and processed by `JGTIDS.py` to add various technical indicators and signals.
-  - The processed data from `JGTIDS.py` is then used by `JGTCDS.py` to create CDS files. The module adds additional indicators and signals to the data, such as fractal divergent bar signals, zero line cross signals, and zone signals.
-  - The data is cleansed and normalized to ensure it is ready for analysis and charting.
+  - Raw PDS data is first converted into IDS datasets by the `JGTIDS.py` service. This generates the core indicator columns required by later steps.
+  - `JGTCDSSvc.py` invokes `JGTCDS.py` to append CDS‑specific columns such as fractal divergent bar signals, zero line cross signals, and zone signals.
+  - The final dataset is cleansed and normalized to ensure it is ready for analysis and charting.
 
 * **End-Results Produced** 📈
   - The CDS files created by `JGTCDSSvc.py` contain processed financial market data with various technical indicators and signals. These files are used for further analysis, charting, and generating trading signals.

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -1,30 +1,28 @@
 # Narrative Map
 
 ## Commit Timeline
+- 04: updated CDS docs to clarify IDS dependency and added JGTCDS spec 📚🧠
 
+## Archived – Previous Iteration
+### Commit Timeline
 - e4b6746: applying previous commit introducing CLI docs and main entry point.
 - b440b49: add example scripts for each CLI
 - 3956666: Applying previous commit introducing example READMEs.
 - 5d69b85: Applying previous commit introducing extended examples and CLI docs.
 - 0837331: feat(cli): allow fresh and notfresh flags together
 - bb1a509: test: ensure relaxed fresh argument
-
- - a4efcda: introduce relaxed fresh argument helper and update parsers
+- a4efcda: introduce relaxed fresh argument helper and update parsers
 - ba2f9c3: switch to absolute imports for cli_utils helper
- - 716f1f7: align helper imports with other modules using plain module names
-
-These changes allow passing `-new` and `-old` simultaneously without argparse errors. The parsers now use a relaxed helper so jgtapp can default to fresh when needed.
+- 716f1f7: align helper imports with other modules using plain module names
 - a7bacdf: verify CLI compatibility and tests pass
 - 5c5b651: documented JGTADS plotting and mouth water modules; added new data columns specs.
-
 - d54bb49: added operational guide for agents and expanded specs for chart config, request object and mouth/water analysis
 - 4b38cdb: refine mouth/water spec with lookback notes and operational context; create observation loop spec
 - fb667b9: refine dataset column definitions in ADS spec
 - d11c7c5: document SpecLang definition
 - aa273be: applying previous commit introducing more specs and CDS column updates
 
-## Spec Overview
-
+### Spec Overview
 | Spec File | Purpose |
 |-----------|---------|
 | `JGTADS.specs.md` | Describes the multi-panel ADS chart plotting steps and dataset columns. |
@@ -34,6 +32,5 @@ These changes allow passing `-new` and `-old` simultaneously without argparse er
 | `mouth_water_plotter.spec.md` | Outlines overlay creation for mouth/water annotations. |
 | `observation_loop.spec.md` | Summarizes the CLI-driven analysis and voice workflow. |
 
-## Recent Awareness
-
+### Recent Awareness
 Through iterative spec work we realized the documentation itself drives new workflows. The observation loop shows how CLI triggers and voice analysis combine with SpecLang specs to shape trading decisions. Each plotter spec now stands alone so any language can reproduce ADS visuals. This awareness strengthens the repo as a living conversation rather than static code.

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -1,6 +1,7 @@
 # Narrative Map
 
 ## Commit Timeline
+- 05: merged latest `main` into `work` (no changes) 🔄
 - 04: updated CDS docs to clarify IDS dependency and added JGTCDS spec 📚🧠
 
 ## Archived – Previous Iteration

--- a/specs/JGTCDS.spec.md
+++ b/specs/JGTCDS.spec.md
@@ -1,0 +1,18 @@
+# JGTCDS Data Pipeline Specification
+
+This document describes how the `JGTCDS.py` module consumes IDS data and produces Chaos Data Service (CDS) files. The goal is to capture the high-level steps so other implementations can replicate the logic.
+
+## Inputs
+- **IDS dataset** produced by `JGTIDS.py`.
+- Each row represents a market bar with the indicator columns documented in `docs/IDS_data_columns.md`.
+
+## Processing Steps
+1. **Additional Indicators** – append CDS-specific columns such as fractal divergent bar signals, zero line cross signals and zone labels.
+2. **Data Cleansing** – remove invalid rows, normalize column names and ensure timestamps are sorted.
+3. **File Creation** – write the enriched dataset to a CDS file alongside optional zone data files.
+
+## Outputs
+- A CDS file (CSV/Parquet) containing all IDS columns plus the new CDS-specific ones.
+- Optional zone files with aggregated zone data.
+
+The module expects the IDS preprocessing to be complete before running. It does not calculate the base indicators itself but relies entirely on `JGTIDS.py`.


### PR DESCRIPTION
## Summary
- clarify that JGTCDS works from IDS data produced by `JGTIDS.py`
- explain the same in CDSSvc docs and README
- add JGTCDS spec describing its pipeline
- restore old narrative map content and mark archived
- record ledger entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ad54f2c608329aeb81cbf313f6b82