### PR TITLE
Package service scripts for guidecli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Allow `--fresh` and `--notfresh` flags together via `add_use_fresh_argument_relaxed`.
 - Updated CLI modules to use the relaxed parser.
+- Packaged service scripts so guidecli can list them when installed.
  - Updated CLI imports to mirror the package style using `from cli_utils import ...`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,5 @@ global-exclude __pycache__
 global-exclude *.py[co]
 global-exclude .DS_Store
 recursive-include docs/guide_for_llm_agents *
+include *.sh
+include SCRIPTS_README.md

--- a/codex/ledgers/ledger-feature-2506241826.json
+++ b/codex/ledgers/ledger-feature-2506241826.json
@@ -1,0 +1,19 @@
+{
+  "timestamp": "2506241826",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Packaged service scripts so guidecli_jgtpy lists them after installation and documented the new behavior.",
+  "routing": {
+    "files": [
+      "MANIFEST.in",
+      "pyproject.toml",
+      "CHANGELOG.md",
+      "jgtpy/guide_for_llm_agents/jgtservice.md",
+      "narrative-map.md",
+      "specs/guidecli_jgtpy.spec.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": "guidecli_jgtpy --scripts\n\n----\noutput no scripts which should, we dont want to run that from the cloned repository but those scripts should be installed with the published package, revise the pyproject.toml and what happens for that command and this jgtpy/guidecly_jgtpy.py something",
+  "scene": "Before: scripts were excluded from the wheel so the guide command only worked from the repo. After: MANIFEST and pyproject ensure scripts ship with the package and docs mention it.",
+  "glyphs": "⚙️📚"
+}

--- a/jgtpy/guide_for_llm_agents/jgtservice.md
+++ b/jgtpy/guide_for_llm_agents/jgtservice.md
@@ -65,6 +65,7 @@ guidecli_jgtpy --examples
 ```bash
 # List available scripts
 guidecli_jgtpy --scripts
+# These scripts are packaged with the library and work even outside the repo
 
 # Show script content
 guidecli_jgtpy --script refresh-all.sh

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -3,6 +3,7 @@
 ## Commit Timeline
 - 05: merged latest `main` into `work` (no changes) 🔄
 - 04: updated CDS docs to clarify IDS dependency and added JGTCDS spec 📚🧠
+- 06: packaged service scripts so `guidecli_jgtpy --scripts` works outside repo ⚙️📚
 
 ## Archived – Previous Iteration
 ### Commit Timeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ jgtservice-daemon = "jgtpy.jgtservice:main"
 # Environment initialization
 jgt = "jgtpy.jgt_init:main"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.package-data]
 "jgtpy" = [
     "guide_for_llm_agents/*",

--- a/specs/guidecli_jgtpy.spec.md
+++ b/specs/guidecli_jgtpy.spec.md
@@ -1,0 +1,19 @@
+# guidecli_jgtpy Specification
+
+The `guidecli_jgtpy` entry point displays short documentation snippets and 
+service management scripts bundled with the package.
+
+## Documentation Options
+- `--list` lists available documentation sections stored in
+  `jgtpy/guide_for_llm_agents`.
+- `--section <name>` prints the text of a specific section.
+- `--all` prints every section.
+
+## Script Options
+- `--scripts` lists all `*.sh` files shipped alongside the package.
+- `--script <name>` shows the contents of a particular script.
+- `--install-scripts [dir]` copies all scripts to the current or given directory,
+  making them executable.
+
+Scripts are shipped in the published wheel using `MANIFEST.in` so
+`guidecli_jgtpy --scripts` works even when called outside the repository.


### PR DESCRIPTION
## Summary
- include `.sh` service scripts in distribution
- ensure MANIFEST and pyproject ship docs and scripts
- note scripts are packaged in jgtservice guide
- document command in new `guidecli_jgtpy` spec
- update changelog and narrative map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aec74c17c8329978b74d5be0cd520