### PR TITLE
Package service scripts in wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ All notable changes to this project will be documented in this file.
 - Allow `--fresh` and `--notfresh` flags together via `add_use_fresh_argument_relaxed`.
 - Updated CLI modules to use the relaxed parser.
 - Packaged service scripts so guidecli can list them when installed.
+- Fixed wheel packaging to include `jgtpy/scripts` directory.
  - Updated CLI imports to mirror the package style using `from cli_utils import ...`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,5 @@ global-exclude *.py[co]
 global-exclude .DS_Store
 recursive-include docs/guide_for_llm_agents *
 include *.sh
+recursive-include jgtpy/scripts *.sh
 include SCRIPTS_README.md

--- a/codex/ledgers/ledger-feature-2506241900.json
+++ b/codex/ledgers/ledger-feature-2506241900.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2506241900",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Include service scripts inside the wheel so guidecli_jgtpy finds them when installed. Updated specs and docs.",
+  "routing": {
+    "files": [
+      "MANIFEST.in",
+      "pyproject.toml",
+      "jgtpy/__init__.py",
+      "package.json",
+      "CHANGELOG.md",
+      "specs/guidecli_jgtpy.spec.md",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": "guidecli_jgtpy --scripts\nAvailable bash scripts:\nNo scripts found. This might be because:\n1. The package was installed without scripts\n2. You're not in the development directory\n3. Scripts are not properly included in the package\n\nTry running from the package root directory or reinstall the package.\n\n-------\nAgain, I repeat that this options IS NOT FOR WHEN WE RUN THAT FROM THE CLONED REPOSITORY but a new FOLDER where we want the SCRIPTS !!!  I guess they should come from where the package is installed.  Bellow is a proof that they seems to have been forgotted" ,
+  "scene": "Before: wheel lacked jgtpy/scripts so CLI couldn't list scripts outside repo. After: pyproject and manifest include the folder, version bumped to 0.6.14 and docs updated.",
+  "glyphs": "🔧📦"
+}

--- a/jgtpy/__init__.py
+++ b/jgtpy/__init__.py
@@ -36,7 +36,7 @@ with warnings.catch_warnings():
     )
 
 
-version='0.6.13'
+version='0.6.14'
 __version__ = version
 
 

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -4,6 +4,7 @@
 - 05: merged latest `main` into `work` (no changes) 🔄
 - 04: updated CDS docs to clarify IDS dependency and added JGTCDS spec 📚🧠
 - 06: packaged service scripts so `guidecli_jgtpy --scripts` works outside repo ⚙️📚
+- 07: wheel now bundles `jgtpy/scripts` so installed guide finds them 🔧📦
 
 ## Archived – Previous Iteration
 ### Commit Timeline

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jgtpy",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Enhanced JGTPy CDS, IDS, PDSP Services",
   "main": "index.js",
   "directories": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jgtpy"
-version = "0.6.13"
+version = "0.6.14"
 authors = [
   { name="Guillaume Isabelle", email="jgi@jgwill.com" },
 ]
@@ -100,5 +100,6 @@ include-package-data = true
 [tool.setuptools.package-data]
 "jgtpy" = [
     "guide_for_llm_agents/*",
-    "SCRIPTS_README.md"
+    "SCRIPTS_README.md",
+    "scripts/*.sh"
 ]

--- a/specs/guidecli_jgtpy.spec.md
+++ b/specs/guidecli_jgtpy.spec.md
@@ -15,5 +15,6 @@ service management scripts bundled with the package.
 - `--install-scripts [dir]` copies all scripts to the current or given directory,
   making them executable.
 
-Scripts are shipped in the published wheel using `MANIFEST.in` so
-`guidecli_jgtpy --scripts` works even when called outside the repository.
+Scripts reside under `jgtpy/scripts` and are included in the wheel via
+`pyproject.toml` package data. This ensures `guidecli_jgtpy --scripts`
+works even when called outside the repository.


### PR DESCRIPTION
## Summary
- include `scripts/*.sh` via package-data and MANIFEST
- bump version to 0.6.14
- document packaging fix in CHANGELOG and spec
- update narrative map
- add ledger entry for script packaging

## Testing
- `pytest -q`
- `python setup.py bdist_wheel`


------
https://chatgpt.com/codex/tasks/task_e_685af45d9f8c83299c0bad7747481240