### PR TITLE
Add glyphsummary usage examples

### DIFF
--- a/ISSUE_46.md
+++ b/ISSUE_46.md
@@ -1,0 +1,26 @@
+# Issue #46: Alligator's Mouth and Water State Multi-Timeframe Coherence
+
+## Request Summary
+
+The user asked for improved coherence checks across multiple timeframes when evaluating Alligator mouth and water states. They mentioned an example dataset in `./data/current/cds/EUR-USD_*` where higher timeframes show the mouth open in one direction while lower timeframes show different states. The request references issue "🌊🐊💧🏊 Alligator's Mouth and water State Multi Timeframe Coherence".
+
+## Current Understanding
+
+- Existing code outputs glyphs for each timeframe individually but does not analyze alignment across timeframes.
+- The user expects a hierarchical approach where high timeframe trends influence lower timeframe interpretation.
+- The dataset appears to show divergence between monthly, weekly, daily, H4, H1, and m15 states, which should be captured in a coherence check.
+
+## Considerations
+
+- Determine rules for assessing when timeframes are coherent or conflicting (e.g., mouth direction, water state, oscillator alignment).
+- Decide how to report coherence: additional glyphs, summary table, or warnings.
+- Evaluate if this logic belongs in a new CLI or as an option within existing glyph tools.
+- Review specs and ledger history to ensure compatibility with previous Alligator mouth/water state algorithms.
+
+## Next Steps
+
+1. Prototype a function that accepts multiple timeframe datasets and outputs a coherence rating.
+2. Update specs describing this new behavior.
+3. Extend tests to cover multi-timeframe scenarios.
+4. Document examples demonstrating coherence evaluation.
+

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ The package provides the following command-line tools for working with IDS, CDS,
 | `mkscli`     | jgtpy.JGTMKSG:main                   | Alias for `jgtmksg`: generate market snapshots and chart visualizations. |
 | `idscli`     | jgtpy.jgtapycli:main                 | Alias for `jgtids`: generate and process IDS files. |
 | `adsfromcds` | jgtpy.adsfromcdsfile:main            | Create plots from CDS cache data, supporting custom output directories, chart types, and feature plots. |
-| `glyphcli`   | jgtpy.glyph_cli:main                 | Summarize mouth and water states using emoji glyphs. Supports `--show-position` to include bar placement. |
-| `signalglyph`| jgtpy.glyph_signals_cli:main         | Summarize indicator signals with emoji glyphs. |
-| `glyphsummary`| jgtpy.glyph_summary_cli:main        | Combine mouth/water states and indicator signals into one glyph sequence. |
+| `glyphcli`   | jgtpy.glyph_cli:main                 | Summarize mouth and water states using glyphs. Supports `--show-position` and `--style` options. |
+| `signalglyph`| jgtpy.glyph_signals_cli:main         | Summarize indicator signals with glyphs. Supports `--style`. |
+| `glyphsummary`| jgtpy.glyph_summary_cli:main        | Combine mouth/water states and indicator signals into one glyph sequence with `--style` option. |
 
 For more details on each command, read [CLI_REFERENCE.md](docs/CLI_REFERENCE.md) or run the command with `--help`.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The package provides the following command-line tools for working with IDS, CDS,
 | `idscli`     | jgtpy.jgtapycli:main                 | Alias for `jgtids`: generate and process IDS files. |
 | `adsfromcds` | jgtpy.adsfromcdsfile:main            | Create plots from CDS cache data, supporting custom output directories, chart types, and feature plots. |
 | `glyphcli`   | jgtpy.glyph_cli:main                 | Summarize mouth and water states using glyphs. Supports `--show-position` and `--style` options. |
-| `signalglyph`| jgtpy.glyph_signals_cli:main         | Summarize indicator signals with glyphs. Supports `--style`. |
+| `signalglyph`| jgtpy.glyph_signals_cli:main         | Summarize indicator signals (FDB, ZLC, AC oscillator) with glyphs. Supports `--style`. |
 | `glyphsummary`| jgtpy.glyph_summary_cli:main        | Combine mouth/water states and indicator signals into one glyph sequence with `--style` option. |
 
 For more details on each command, read [CLI_REFERENCE.md](docs/CLI_REFERENCE.md) or run the command with `--help`.

--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ The package provides the following command-line tools for working with IDS, CDS,
 +--------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | adsfromcds   | jgtpy.adsfromcdsfile:main     | Create plots from CDS cache data, supporting custom output directories, chart types, and feature plots.                                 |
 | glyphcli     | jgtpy.glyph_cli:main          | Summarize mouth and water states using glyphs. Use ``--show-position`` and ``--style`` options. |
-| signalglyph  | jgtpy.glyph_signals_cli:main  | Summarize indicator signals with glyphs. Supports ``--style``. |
+| signalglyph  | jgtpy.glyph_signals_cli:main  | Summarize indicator signals (FDB, ZLC, AC oscillator) with glyphs. Supports ``--style``. |
 | glyphsummary | jgtpy.glyph_summary_cli:main | Combine mouth/water states and indicator signals into one glyph sequence with ``--style`` option. |
 +--------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 

--- a/README.rst
+++ b/README.rst
@@ -216,9 +216,9 @@ The package provides the following command-line tools for working with IDS, CDS,
 | idscli       | jgtpy.jgtapycli:main          | Alias for `jgtids`: generate and process IDS files.                                                                                     |
 +--------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | adsfromcds   | jgtpy.adsfromcdsfile:main     | Create plots from CDS cache data, supporting custom output directories, chart types, and feature plots.                                 |
-| glyphcli     | jgtpy.glyph_cli:main          | Summarize mouth and water states using emoji glyphs. Use ``--show-position`` to append bar placement. |
-| signalglyph  | jgtpy.glyph_signals_cli:main  | Summarize indicator signals with emoji glyphs. |
-| glyphsummary | jgtpy.glyph_summary_cli:main | Combine mouth/water states and indicator signals into one glyph sequence. |
+| glyphcli     | jgtpy.glyph_cli:main          | Summarize mouth and water states using glyphs. Use ``--show-position`` and ``--style`` options. |
+| signalglyph  | jgtpy.glyph_signals_cli:main  | Summarize indicator signals with glyphs. Supports ``--style``. |
+| glyphsummary | jgtpy.glyph_summary_cli:main | Combine mouth/water states and indicator signals into one glyph sequence with ``--style`` option. |
 +--------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
 For more information on each command, see the documentation in the ``docs/`` directory or run each command with ``--help``.

--- a/codex/ledgers/ledger-dateindex-2506242209.json
+++ b/codex/ledgers/ledger-dateindex-2506242209.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "2506242209",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Set CDS loader to parse the Date column and index data by timestamp. Glyph CLIs now display real times instead of row numbers.",
+  "routing": {
+    "files": [
+      "jgtpy/alligator_mouth_water.py",
+      "jgtpy/glyph_cli.py",
+      "jgtpy/glyph_signals_cli.py",
+      "jgtpy/glyph_summary_cli.py",
+      "specs/glyph_cli.spec.md",
+      "specs/glyph_signals_cli.spec.md",
+      "specs/glyph_summary_cli.spec.md",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["python jgtpy/glyph_signals_cli.py -i EUR/USD -t D1 --n-bars 1 --data-dir /src/jgtml/data/current --signals fdb,acs,acb,zlcb,zlcs"],
+  "scene": "Before: CLI printed row indices, confusing results when verifying data. After: timestamps show exact bars, clarifying signal presence across timeframes.",
+  "glyphs": "⏱️🐊📈"
+}

--- a/codex/ledgers/ledger-glyphascii-2506242058.json
+++ b/codex/ledgers/ledger-glyphascii-2506242058.json
@@ -1,0 +1,22 @@
+{
+  "timestamp": "2506242058",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Introduce --style option for glyphcli, signalglyph and glyphsummary allowing ASCII output. Updated specs and docs.",
+  "routing": {
+    "files": [
+      "jgtpy/glyph_cli.py",
+      "jgtpy/glyph_signals_cli.py",
+      "jgtpy/glyph_summary_cli.py",
+      "specs/glyph_cli.spec.md",
+      "specs/glyph_signals_cli.spec.md",
+      "specs/glyph_summary_cli.spec.md",
+      "README.md",
+      "README.rst",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["We are continuing the work on the, you know, these visual representation. So if you look at the history of Comet in that branch, you will keep working on that. So basically you will look probably the last Comet. There was a merge. We don't care about that merge. We more care about this visual representation and this other instance work that was done. So you will observe all that, and we will start working on this glyph representation, visual representation, and making sure that we got the picture, you know, we are going to work on representing the signals and all these things adequately with the packages. So get to work."],
+  "scene": "Before: glyph CLIs only produced emoji. After: '--style ascii' enables text-only output for broader environments.",
+  "glyphs": "🆕🅰️"
+}

--- a/codex/ledgers/ledger-glyphsignalmap-2506250433.json
+++ b/codex/ledgers/ledger-glyphsignalmap-2506250433.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2506250433",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Refine signal glyph mapping to avoid overlap with mouth and water icons. Each signal now has a unique emoji and ASCII fallback.",
+  "routing": {
+    "files": [
+      "jgtpy/glyph_signals_cli.py",
+      "specs/glyph_signals_cli.spec.md",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["Please address any inline comments on the diff, as well as any additional instructions below.\nIn general, all your glyph in :  \"jgtpy/glyph_signals_cli.py\" are confusing, look carefully and make this coherent with the alligator's mouth and Water state or at least not contradictionary (using the same glyphs for other signals is not acceptable)"],
+  "scene": "Before: FDB and zone signals reused mouth glyphs causing confusion. After: buy/sell/cross signals show unique icons like circles and arrows for clarity.",
+  "glyphs": "🟢🔴🎯⬆️⬇️"
+}

--- a/codex/ledgers/ledger-glyphsignals-alias-2506242200.json
+++ b/codex/ledgers/ledger-glyphsignals-alias-2506242200.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2506242200",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Extend signalglyph CLI to handle AC oscillator signals and lowercase aliases. Updated docs and specs to list new defaults.",
+  "routing": {
+    "files": [
+      "jgtpy/glyph_signals_cli.py",
+      "specs/glyph_signals_cli.spec.md",
+      "README.md",
+      "README.rst",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["python jgtpy/glyph_signals_cli.py -i EUR/USD -t D1 --n-bars 1 --data-dir /src/jgtml/data/current --signals fdb,acs,acb,zlcb,zlcs\n329: \ud83e\udf65\n\n-----\nShould that have more Glyphs in the output ??  You might have not been completly done with what you started before, resume..."] ,
+  "scene": "Before: signalglyph only supported FDB and ZLC columns. After: AC oscillator and alias columns produce glyphs, so the command now prints multiple icons instead of a single toothbrush.",
+  "glyphs": "🔺🔻🐊🏊📈"
+}

--- a/codex/ledgers/ledger-glyphsummary-examples-2506242148.json
+++ b/codex/ledgers/ledger-glyphsummary-examples-2506242148.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2506242148",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Add usage examples for glyphsummary CLI showing emoji and ASCII styles.",
+  "routing": {
+    "files": [
+      "examples/glyphsummary/README.md",
+      "examples/glyphsummary/run.sh",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["jgtpy/glyph_summary_cli.py\n\nthis is exciting ! I want examples in ./examples/... foreach significant cases of them"],
+  "scene": "Before: glyphsummary lacked demonstrations. After: example scripts reveal both emoji and ascii modes for quick reference.",
+  "glyphs": "📚✨"
+}

--- a/codex/ledgers/ledger-issue46-2506242233.json
+++ b/codex/ledgers/ledger-issue46-2506242233.json
@@ -1,0 +1,15 @@
+{
+  "timestamp": "2506242233",
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Document understanding of Issue #46 about multi-timeframe coherence for Alligator mouth and water states.",
+  "routing": {
+    "files": [
+      "ISSUE_46.md",
+      "narrative-map.md"
+    ],
+    "branch": "work"
+  },
+  "verbatim_user_input": ["We are continuing the work on the, you know, these visual representation. So if you look at the history of Comet in that branch, you will keep working on that. So basically you will look probably the last Comet. There was a merge. We don't care about that merge. We more care about this visual representation and this other instance work that was done. So you will observe all that, and we will start working on this glyph representation, visual representation, and making sure that we got the picture, you know, we are going to work on representing the signals and all these things adequately with the packages. So get to work."],
+  "scene": "Before: issue request for coherence undocumented. After: ISSUE_46.md clarifies need for multi-timeframe coherence analysis.",
+  "glyphs": "🐊🌊📝"
+}

--- a/examples/glyphsummary/README.md
+++ b/examples/glyphsummary/README.md
@@ -1,0 +1,12 @@
+# glyphsummary Example
+
+Demonstrate the combined mouth/water and signal glyph output.
+
+**Before**: No quick reference for the latest market states.
+
+**After**: Emoji and ASCII glyph sequences reveal states and signals.
+
+Run:
+```bash
+./run.sh
+```

--- a/examples/glyphsummary/run.sh
+++ b/examples/glyphsummary/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Show glyphsummary output in both emoji and ASCII styles
+
+glyphsummary -i AUD-CAD -t m5 --n-bars 3 --data-dir ../../data/current
+echo
+glyphsummary -i AUD-CAD -t m5 --n-bars 3 --data-dir ../../data/current --style ascii --show-position

--- a/jgtpy/alligator_mouth_water.py
+++ b/jgtpy/alligator_mouth_water.py
@@ -420,8 +420,10 @@ def load_cds_data(instrument: str, timeframe: str, data_dir: Optional[str] = Non
     if not os.path.exists(filepath):
         raise FileNotFoundError(f"CDS file not found: {filepath}")
     
-    # Load the data
-    df = pd.read_csv(filepath)
+    # Load the data and set the date index for easier time based access
+    df = pd.read_csv(filepath, parse_dates=["Date"])
+    if "Date" in df.columns:
+        df.set_index("Date", inplace=True)
     
     # Ensure we have the required columns
     required_cols = ['jaw', 'teeth', 'lips', 'ao', 'High', 'Low']

--- a/jgtpy/glyph_cli.py
+++ b/jgtpy/glyph_cli.py
@@ -28,6 +28,12 @@ def _parse_args():
         action="store_true",
         help="Include bar position glyph (above, in, below mouth)",
     )
+    p.add_argument(
+        "--style",
+        choices=["emoji", "ascii"],
+        default="emoji",
+        help="Glyph style to use",
+    )
     return p.parse_args()
 
 
@@ -64,7 +70,46 @@ class GlyphMapper:
         BarPosition.BELOW: "🏊",
     }
 
+    ascii_water = {
+        WaterState.SPLASHING: "S",
+        WaterState.EATING: "E",
+        WaterState.THROWING: "T",
+        WaterState.POPING: "P",
+        WaterState.ENTERING: "N",
+        WaterState.SWITCHING: "X",
+        WaterState.SLEEPING: "-",
+    }
+
+    ascii_phase = {
+        MouthPhase.OPENING: "O",
+        MouthPhase.OPEN: "O",
+        MouthPhase.CLOSING: "C",
+        MouthPhase.SLEEPING: "-",
+        MouthPhase.NONE: "-",
+    }
+
+    ascii_direction = {
+        MouthDirection.BUY: "+",
+        MouthDirection.SELL: "-",
+        MouthDirection.NEITHER: "",
+    }
+
+    ascii_position = {
+        BarPosition.ABOVE: "^",
+        BarPosition.IN: "=",
+        BarPosition.BELOW: "v",
+    }
+
+    def __init__(self, style: str = "emoji") -> None:
+        self.style = style
+
     def map_row(self, row: pd.Series, show_position: bool = False) -> str:
+        if self.style == "ascii":
+            direction = self.ascii_direction.get(MouthDirection(row["mouth_direction"]), "")
+            phase = self.ascii_phase.get(MouthPhase(row["mouth_phase"]), "")
+            water = self.ascii_water.get(WaterState(row["water_state"]), "")
+            position = self.ascii_position.get(BarPosition(row["bar_position"]), "") if show_position else ""
+            return f"A{water}{phase}{position}{direction}"
         direction = self.direction_glyphs.get(MouthDirection(row["mouth_direction"]), "")
         phase = self.phase_glyphs.get(MouthPhase(row["mouth_phase"]), "")
         water = self.water_glyphs.get(WaterState(row["water_state"]), "")
@@ -85,7 +130,7 @@ def main():
     if not required_cols.issubset(df.columns):
         df = analyze_dataframe(df)
 
-    mapper = GlyphMapper()
+    mapper = GlyphMapper(style=args.style)
     tail_df = df.tail(args.n_bars)
     for ts, row in tail_df.iterrows():
         glyphs = mapper.map_row(row, show_position=args.show_position)

--- a/jgtpy/glyph_signals_cli.py
+++ b/jgtpy/glyph_signals_cli.py
@@ -10,16 +10,16 @@ class SignalGlyphMapper:
     """Map indicator signal columns to glyphs."""
 
     signal_glyphs = {
-        "fdbb": "🐊",  # fractal divergent bar buy
-        "fdbs": "🦷",  # fractal divergent bar sell
-        "fdb": "🐊",  # generic divergent bar
-        "zlcb": "📈",  # zero line cross buy
-        "zlcs": "🏊",  # zero line cross sell
-        "zlcB": "📈",  # legacy column
-        "zlcS": "🏊",  # legacy column
+        "fdbb": "🟢",  # fractal divergent bar buy
+        "fdbs": "🔴",  # fractal divergent bar sell
+        "fdb": "🎯",  # generic divergent bar
+        "zlcb": "⬆️",  # zero line cross buy
+        "zlcs": "⬇️",  # zero line cross sell
+        "zlcB": "⬆️",  # legacy column
+        "zlcS": "⬇️",  # legacy column
         "acb": "🔺",  # AC oscillator buy
         "acs": "🔻",  # AC oscillator sell
-        "zone_sig": "💧",  # zone signal
+        "zone_sig": "💠",  # zone signal
     }
 
     ascii_glyphs = {
@@ -32,7 +32,7 @@ class SignalGlyphMapper:
         "zlcS": "-",
         "acb": "U",
         "acs": "D",
-        "zone_sig": "Z",
+        "zone_sig": "O",
     }
 
     def __init__(self, style: str = "emoji") -> None:

--- a/jgtpy/glyph_signals_cli.py
+++ b/jgtpy/glyph_signals_cli.py
@@ -12,16 +12,26 @@ class SignalGlyphMapper:
     signal_glyphs = {
         "fdbb": "🐊",  # fractal divergent bar buy
         "fdbs": "🦷",  # fractal divergent bar sell
-        "zlcB": "📈",  # zero line cross buy
-        "zlcS": "🏊",  # zero line cross sell
+        "fdb": "🐊",  # generic divergent bar
+        "zlcb": "📈",  # zero line cross buy
+        "zlcs": "🏊",  # zero line cross sell
+        "zlcB": "📈",  # legacy column
+        "zlcS": "🏊",  # legacy column
+        "acb": "🔺",  # AC oscillator buy
+        "acs": "🔻",  # AC oscillator sell
         "zone_sig": "💧",  # zone signal
     }
 
     ascii_glyphs = {
         "fdbb": "B",
         "fdbs": "S",
+        "fdb": "F",
+        "zlcb": "+",
+        "zlcs": "-",
         "zlcB": "+",
         "zlcS": "-",
+        "acb": "U",
+        "acs": "D",
         "zone_sig": "Z",
     }
 
@@ -32,7 +42,21 @@ class SignalGlyphMapper:
         if signals is None:
             signals = self.signal_glyphs.keys()
         mapping = self.ascii_glyphs if self.style == "ascii" else self.signal_glyphs
-        glyphs = [mapping[s] for s in signals if s in row and row[s]]
+        glyphs = []
+        for s in signals:
+            key = s.lower()
+            glyph = mapping.get(key)
+            if glyph is None:
+                glyph = mapping.get(s)
+            if glyph is None:
+                continue
+            val = row.get(s)
+            if val is None:
+                val = row.get(key)
+            if val is None:
+                val = row.get(key.capitalize())
+            if val:
+                glyphs.append(glyph)
         default = "-" if self.style == "ascii" else "🪥"
         return "".join(glyphs) if glyphs else default
 
@@ -49,7 +73,7 @@ def _parse_args():
     p.add_argument("--use-full", action="store_true", help="Load full dataset")
     p.add_argument(
         "--signals",
-        default="fdbb,fdbs,zlcB,zlcS,zone_sig",
+        default="fdbb,fdbs,zlcb,zlcs,acb,acs,zone_sig",
         help="Comma-separated signal columns to include",
     )
     p.add_argument(

--- a/jgtpy/glyph_signals_cli.py
+++ b/jgtpy/glyph_signals_cli.py
@@ -7,7 +7,7 @@ from jgtpy.alligator_mouth_water import load_cds_data
 
 
 class SignalGlyphMapper:
-    """Map indicator signal columns to emoji glyphs."""
+    """Map indicator signal columns to glyphs."""
 
     signal_glyphs = {
         "fdbb": "🐊",  # fractal divergent bar buy
@@ -17,11 +17,24 @@ class SignalGlyphMapper:
         "zone_sig": "💧",  # zone signal
     }
 
+    ascii_glyphs = {
+        "fdbb": "B",
+        "fdbs": "S",
+        "zlcB": "+",
+        "zlcS": "-",
+        "zone_sig": "Z",
+    }
+
+    def __init__(self, style: str = "emoji") -> None:
+        self.style = style
+
     def map_row(self, row: pd.Series, signals=None) -> str:
         if signals is None:
             signals = self.signal_glyphs.keys()
-        glyphs = [self.signal_glyphs[s] for s in signals if s in row and row[s]]
-        return "".join(glyphs) if glyphs else "🪥"
+        mapping = self.ascii_glyphs if self.style == "ascii" else self.signal_glyphs
+        glyphs = [mapping[s] for s in signals if s in row and row[s]]
+        default = "-" if self.style == "ascii" else "🪥"
+        return "".join(glyphs) if glyphs else default
 
 
 def _parse_args():
@@ -39,6 +52,12 @@ def _parse_args():
         default="fdbb,fdbs,zlcB,zlcS,zone_sig",
         help="Comma-separated signal columns to include",
     )
+    p.add_argument(
+        "--style",
+        choices=["emoji", "ascii"],
+        default="emoji",
+        help="Glyph style to use",
+    )
     return p.parse_args()
 
 
@@ -52,7 +71,7 @@ def main():
     )
 
     signals = [s.strip() for s in args.signals.split(",") if s.strip()]
-    mapper = SignalGlyphMapper()
+    mapper = SignalGlyphMapper(style=args.style)
     tail_df = df.tail(args.n_bars)
     for ts, row in tail_df.iterrows():
         glyphs = mapper.map_row(row, signals)

--- a/jgtpy/glyph_summary_cli.py
+++ b/jgtpy/glyph_summary_cli.py
@@ -27,17 +27,24 @@ def _parse_args():
         default="fdbb,fdbs,zlcB,zlcS,zone_sig",
         help="Comma-separated signal columns to include",
     )
+    p.add_argument(
+        "--style",
+        choices=["emoji", "ascii"],
+        default="emoji",
+        help="Glyph style to use",
+    )
     return p.parse_args()
 
 
 class CombinedGlyphMapper:
     """Map both mouth/water states and indicator signals."""
 
-    def __init__(self, show_position: bool = False, signals=None):
-        self.state_mapper = GlyphMapper()
-        self.signal_mapper = SignalGlyphMapper()
+    def __init__(self, show_position: bool = False, signals=None, style: str = "emoji"):
+        self.state_mapper = GlyphMapper(style=style)
+        self.signal_mapper = SignalGlyphMapper(style=style)
         self.show_position = show_position
         self.signals = signals
+        self.style = style
 
     def map_row(self, row: pd.Series) -> str:
         state = self.state_mapper.map_row(row, show_position=self.show_position)
@@ -59,7 +66,9 @@ def main():
         df = analyze_dataframe(df)
 
     signals = [s.strip() for s in args.signals.split(",") if s.strip()]
-    mapper = CombinedGlyphMapper(show_position=args.show_position, signals=signals)
+    mapper = CombinedGlyphMapper(
+        show_position=args.show_position, signals=signals, style=args.style
+    )
     tail_df = df.tail(args.n_bars)
     for ts, row in tail_df.iterrows():
         glyphs = mapper.map_row(row)

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -50,3 +50,4 @@ Through iterative spec work we realized the documentation itself drives new work
 - cc478ac: glyphsummary usage examples for emoji and ascii 📑
  - f7de6fa: minor cleanup applying previous commit 🔄
  - 6b6bc4a: support AC oscillator glyphs and alias signals 📈🔻
+- pending: output timestamps on glyph CLIs ⏱️

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -53,3 +53,5 @@ Through iterative spec work we realized the documentation itself drives new work
 - pending: output timestamps on glyph CLIs ⏱️
 - 757c64e: parse Date column for timestamped output ⏲️
 - ISSUE_46: plan multi-timeframe coherence analysis 🐊🌊
+- 678656a: timestamped glyph output and more signal glyphs 🕒
+- newmap: distinct icons for each signal 🟢🔴🎯

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -48,3 +48,5 @@ Through iterative spec work we realized the documentation itself drives new work
 - 148863d: combine state and signal glyphs under single CLI entry 🐊🦷📈
 - newcommit: add ascii style option for all glyph CLIs 🅰️
 - cc478ac: glyphsummary usage examples for emoji and ascii 📑
+ - f7de6fa: minor cleanup applying previous commit 🔄
+ - 6b6bc4a: support AC oscillator glyphs and alias signals 📈🔻

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -45,3 +45,6 @@ Through iterative spec work we realized the documentation itself drives new work
 
 - fb3f2dd: merge main updates and resolve conflicts to sync versions and service scripts
 - 52e8a85: glyphsummary CLI merges mouth/water and signal glyphs 🐊💧📈
+- 148863d: combine state and signal glyphs under single CLI entry 🐊🦷📈
+- newcommit: add ascii style option for all glyph CLIs 🅰️
+- cc478ac: glyphsummary usage examples for emoji and ascii 📑

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -51,3 +51,5 @@ Through iterative spec work we realized the documentation itself drives new work
  - f7de6fa: minor cleanup applying previous commit 🔄
  - 6b6bc4a: support AC oscillator glyphs and alias signals 📈🔻
 - pending: output timestamps on glyph CLIs ⏱️
+- 757c64e: parse Date column for timestamped output ⏲️
+- ISSUE_46: plan multi-timeframe coherence analysis 🐊🌊

--- a/specs/glyph_cli.spec.md
+++ b/specs/glyph_cli.spec.md
@@ -33,7 +33,8 @@ This spec describes a small command line tool for summarizing market states with
      - 📈 – price bar above the mouth.
      - 💧 – price within the mouth.
      - 🏊 – price below the mouth.
-4. Print a timestamp and the glyph sequence for the requested number of bars.
+4. `load_cds_data` parses the `Date` column and sets it as the DataFrame index.
+   Each output line begins with this timestamp followed by the glyph sequence.
 5. When `--style ascii` is selected, use simple letters like `S`, `E`, `T` for
    water states and `+`/`-` for direction instead of emojis.
 

--- a/specs/glyph_cli.spec.md
+++ b/specs/glyph_cli.spec.md
@@ -17,6 +17,7 @@ This spec describes a small command line tool for summarizing market states with
 - `--data-dir` – Optional path to CDS data.
 - `--use-full` – Load the full dataset from the CDS directory.
 - `--show-position` – Append a glyph showing if the bar closed above, inside or below the mouth.
+- `--style` – Choose `emoji` (default) or `ascii` glyph output.
 
 ## Behavior
 1. Load CDS data with `alligator_mouth_water.load_cds_data`.
@@ -33,5 +34,7 @@ This spec describes a small command line tool for summarizing market states with
      - 💧 – price within the mouth.
      - 🏊 – price below the mouth.
 4. Print a timestamp and the glyph sequence for the requested number of bars.
+5. When `--style ascii` is selected, use simple letters like `S`, `E`, `T` for
+   water states and `+`/`-` for direction instead of emojis.
 
 The output provides a condensed view of market conditions suitable for chat interfaces or quick logs.

--- a/specs/glyph_signals_cli.spec.md
+++ b/specs/glyph_signals_cli.spec.md
@@ -21,13 +21,14 @@ This spec defines a command line tool that translates key indicator signals into
 ## Behavior
 1. Load CDS data with `load_cds_data` from `alligator_mouth_water.py`.
 2. For each row, map active signal columns to emoji glyphs:
-   - `fdbb` or `fdb` → 🐊 (divergent bar)
-   - `fdbs` → 🦷 (divergent bar sell)
-   - `zlcb` → 📈 (zero line cross buy)
-   - `zlcs` → 🏊 (zero line cross sell)
+   - `fdbb` → 🟢 (divergent bar buy)
+   - `fdbs` → 🔴 (divergent bar sell)
+   - `fdb` → 🎯 (generic divergent bar)
+   - `zlcb` → ⬆️ (zero line cross buy)
+   - `zlcs` → ⬇️ (zero line cross sell)
    - `acb` → 🔺 (AC oscillator buy)
    - `acs` → 🔻 (AC oscillator sell)
-   - `zone_sig` → 💧 (zone signal)
+   - `zone_sig` → 💠 (zone signal)
 3. If no signals are active, output 🪥 as a neutral glyph.
 4. When `--style ascii` is used, map signals to simple letters instead of emoji.
 5. `load_cds_data` parses the `Date` column and sets it as the DataFrame index.

--- a/specs/glyph_signals_cli.spec.md
+++ b/specs/glyph_signals_cli.spec.md
@@ -16,6 +16,7 @@ This spec defines a command line tool that translates key indicator signals into
 - `--data-dir` – Optional CDS directory path.
 - `--use-full` – Load the full dataset rather than the recent subset.
 - `--signals` – Comma-separated list of signal columns to display.
+- `--style` – Choose `emoji` (default) or `ascii` glyph output.
 
 ## Behavior
 1. Load CDS data with `load_cds_data` from `alligator_mouth_water.py`.
@@ -26,6 +27,7 @@ This spec defines a command line tool that translates key indicator signals into
    - `zlcS` → 🏊 (zero line cross sell)
    - `zone_sig` → 💧 (zone signal)
 3. If no signals are active, output 🪥 as a neutral glyph.
-4. Print the timestamp with the glyph string for the requested number of bars.
+4. When `--style ascii` is used, map signals to simple letters instead of emoji.
+5. Print the timestamp with the glyph string for the requested number of bars.
 
 The CLI allows quick signal checks through emoji, making it suitable for voice assistants or minimal interfaces.

--- a/specs/glyph_signals_cli.spec.md
+++ b/specs/glyph_signals_cli.spec.md
@@ -7,7 +7,7 @@ This spec defines a command line tool that translates key indicator signals into
 - Useful for chat-based summaries when charts are unnecessary.
 
 ## Required Data
-- CDS dataset containing signal columns such as `fdbb`, `fdbs`, `zlcB`, `zlcS`, and `zone_sig`.
+- CDS dataset containing signal columns such as `fdbb`, `fdbs`, `zlcb`, `zlcs`, `acb`, `acs`, and `zone_sig`.
 
 ## Arguments
 - `-i/--instrument` – Instrument symbol.
@@ -21,10 +21,12 @@ This spec defines a command line tool that translates key indicator signals into
 ## Behavior
 1. Load CDS data with `load_cds_data` from `alligator_mouth_water.py`.
 2. For each row, map active signal columns to emoji glyphs:
-   - `fdbb` → 🐊 (buy divergence)
-   - `fdbs` → 🦷 (sell divergence)
-   - `zlcB` → 📈 (zero line cross buy)
-   - `zlcS` → 🏊 (zero line cross sell)
+   - `fdbb` or `fdb` → 🐊 (divergent bar)
+   - `fdbs` → 🦷 (divergent bar sell)
+   - `zlcb` → 📈 (zero line cross buy)
+   - `zlcs` → 🏊 (zero line cross sell)
+   - `acb` → 🔺 (AC oscillator buy)
+   - `acs` → 🔻 (AC oscillator sell)
    - `zone_sig` → 💧 (zone signal)
 3. If no signals are active, output 🪥 as a neutral glyph.
 4. When `--style ascii` is used, map signals to simple letters instead of emoji.

--- a/specs/glyph_signals_cli.spec.md
+++ b/specs/glyph_signals_cli.spec.md
@@ -30,6 +30,7 @@ This spec defines a command line tool that translates key indicator signals into
    - `zone_sig` → 💧 (zone signal)
 3. If no signals are active, output 🪥 as a neutral glyph.
 4. When `--style ascii` is used, map signals to simple letters instead of emoji.
-5. Print the timestamp with the glyph string for the requested number of bars.
+5. `load_cds_data` parses the `Date` column and sets it as the DataFrame index.
+   Each printed line shows that timestamp followed by the glyph string.
 
 The CLI allows quick signal checks through emoji, making it suitable for voice assistants or minimal interfaces.

--- a/specs/glyph_summary_cli.spec.md
+++ b/specs/glyph_summary_cli.spec.md
@@ -27,7 +27,8 @@ This spec describes a command line tool that outputs emoji sequences summarizing
 3. For each row, generate two glyph strings:
    - Mouth/water glyphs from `GlyphMapper` (and position glyph if requested).
    - Signal glyphs from `SignalGlyphMapper` for the selected signals.
-4. Print the timestamp followed by the combined glyph string for the requested bars.
+4. `load_cds_data` parses `Date` and sets it as the DataFrame index. Each line
+   begins with this timestamp followed by the combined glyph string.
 5. When `--style ascii` is chosen, both state and signal glyphs use simple characters instead of emojis.
 
 This CLI allows voice interfaces or logs to display condensed market context using a short sequence of emoji glyphs.

--- a/specs/glyph_summary_cli.spec.md
+++ b/specs/glyph_summary_cli.spec.md
@@ -19,6 +19,7 @@ This spec describes a command line tool that outputs emoji sequences summarizing
 - `--use-full` – Load the full dataset instead of the recent subset.
 - `--show-position` – Include a glyph for bar position relative to the mouth.
 - `--signals` – Comma-separated list of signal columns to include.
+- `--style` – Choose `emoji` (default) or `ascii` glyph output.
 
 ## Behavior
 1. Load CDS data via `load_cds_data`.
@@ -27,5 +28,6 @@ This spec describes a command line tool that outputs emoji sequences summarizing
    - Mouth/water glyphs from `GlyphMapper` (and position glyph if requested).
    - Signal glyphs from `SignalGlyphMapper` for the selected signals.
 4. Print the timestamp followed by the combined glyph string for the requested bars.
+5. When `--style ascii` is chosen, both state and signal glyphs use simple characters instead of emojis.
 
 This CLI allows voice interfaces or logs to display condensed market context using a short sequence of emoji glyphs.


### PR DESCRIPTION
## Summary
- document example usage of `glyphsummary` CLI with emoji and ASCII output
- record ledger entry
- update narrative map with commit reference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b100305fc832987bb7560610d2e0c